### PR TITLE
Implement game event domain classes

### DIFF
--- a/backend/core_game/game_event/domain.py
+++ b/backend/core_game/game_event/domain.py
@@ -1,0 +1,84 @@
+"""Domain classes for working with game event models."""
+
+from .schemas import (
+    NPCConversationEventModel,
+    PlayerNPCConversationEventModel,
+    NarratorInterventionEventModel,
+    CutsceneFrameModel,
+    CutsceneEventModel,
+    NPCMessage,
+    NarratorMessage,
+    GameEventModel,
+)
+
+
+class BaseGameEvent:
+    """Common functionality for domain event wrappers.
+
+    Parameters
+    ----------
+    model:
+        The Pydantic model storing the event data.
+    """
+
+    def __init__(self, model: GameEventModel):
+        self._data = model
+
+    @property
+    def id(self) -> str:
+        """Return the unique identifier of the underlying event model."""
+        return self._data.id
+
+
+class NPCConversationEvent(BaseGameEvent):
+    """Domain logic for an NPC-only conversation."""
+
+    def __init__(self, model: NPCConversationEventModel):
+        super().__init__(model)
+
+    def add_message(self, message: NPCMessage) -> None:
+        self._data.messages.append(message)
+
+
+class PlayerNPCConversationEvent(BaseGameEvent):
+    """Domain logic for a conversation involving the player and NPCs."""
+
+    def __init__(self, model: PlayerNPCConversationEventModel):
+        super().__init__(model)
+
+    def add_message(self, message: NPCMessage) -> None:
+        self._data.messages.append(message)
+
+
+class NarratorInterventionEvent(BaseGameEvent):
+    """Domain logic for narrator interventions."""
+
+    def __init__(self, model: NarratorInterventionEventModel):
+        super().__init__(model)
+
+    def add_message(self, message: NarratorMessage) -> None:
+        self._data.messages.append(message)
+
+
+class CutsceneFrame:
+    """Domain wrapper around :class:`CutsceneFrameModel`."""
+
+    def __init__(self, model: CutsceneFrameModel):
+        self._data: CutsceneFrameModel = model
+
+    def add_narrator_message(self, message: NarratorMessage) -> None:
+        self._data.narrator_messages.append(message)
+
+    def add_npc_message(self, message: NPCMessage) -> None:
+        self._data.npc_messages.append(message)
+
+
+class CutsceneEvent(BaseGameEvent):
+    """Domain logic for cutscene events."""
+
+    def __init__(self, model: CutsceneEventModel):
+        super().__init__(model)
+
+    def add_frame(self, frame: CutsceneFrameModel) -> None:
+        self._data.frames.append(frame)
+

--- a/backend/core_game/game_event/schemas.py
+++ b/backend/core_game/game_event/schemas.py
@@ -1,5 +1,157 @@
-from typing import Dict, List, Optional, Literal, Any
+"""Data models for describing game events and in-game messages."""
+
+from typing import List, Optional, Literal, Union
 from pydantic import BaseModel, Field
 
+
 class GameEventModel(BaseModel):
-    id: str = Field(...,description="id of the game event")
+    """Base class for all game events."""
+    id: str = Field(..., description="Unique identifier of the game event.")
+
+
+# ---------- Message Schemas ----------
+
+
+class MessageBase(BaseModel):
+    """Base fields shared by all messages."""
+
+    content: str = Field(..., description="Text or description of the message.")
+
+
+class SpokenMessage(MessageBase):
+    """Dialogue line spoken by an actor."""
+
+    type: Literal["spoken"] = Field("spoken", description="Spoken line of dialogue.")
+
+
+class ActionMessage(MessageBase):
+    """Descriptive action performed by an actor."""
+
+    type: Literal["action"] = Field(
+        "action", description="Descriptive action performed by the actor."
+    )
+
+
+class ObservationMessage(MessageBase):
+    """Narrator observation not directly addressed to the player."""
+
+    type: Literal["observation"] = Field(
+        "observation", description="Narrator observation or description."
+    )
+
+
+class ActorMessageMixin(BaseModel):
+    """Mixin for messages that include the sender's identifier."""
+
+    actor_id: str = Field(..., description="ID of the actor sending the message.")
+
+
+class NPCSpokenMessage(SpokenMessage, ActorMessageMixin):
+    pass
+
+
+class NPCActionMessage(ActionMessage, ActorMessageMixin):
+    pass
+
+
+NPCMessage = Union[NPCSpokenMessage, NPCActionMessage]
+
+
+class PlayerSpokenMessage(SpokenMessage):
+    pass
+
+
+class PlayerActionMessage(ActionMessage):
+    pass
+
+
+PlayerMessage = Union[PlayerSpokenMessage, PlayerActionMessage]
+
+
+class NarratorSpokenMessage(SpokenMessage):
+    """Line the narrator directs straight to the player."""
+
+
+class NarratorObservationMessage(ObservationMessage):
+    """Narrator comment describing the scene without addressing the player."""
+
+
+# Narrator messages can either address the player directly (spoken) or simply
+# describe what happens in the scene (observation).
+NarratorMessage = Union[NarratorSpokenMessage, NarratorObservationMessage]
+
+
+# ---------- Event Schemas ----------
+class NPCConversationEventModel(GameEventModel):
+    """Conversation between several NPCs."""
+    type: Literal["npc_conversation"] = Field(
+        "npc_conversation", description="Type discriminator for this event."
+    )
+    npc_ids: List[str] = Field(
+        ..., description="IDs of the NPCs participating in the conversation."
+    )
+    messages: List[NPCMessage] = Field(
+        default_factory=list,
+        description="Ordered list of NPC messages and actions.",
+    )
+
+
+class PlayerNPCConversationEventModel(GameEventModel):
+    """Conversation between the player and one or more NPCs."""
+    type: Literal["player_npc_conversation"] = Field(
+        "player_npc_conversation",
+        description="Type discriminator for this event.",
+    )
+    npc_ids: List[str] = Field(
+        ..., description="IDs of the NPCs participating in the conversation."
+    )
+    messages: List[NPCMessage] = Field(
+        default_factory=list,
+        description="Ordered list of NPC messages and actions before player intervention.",
+    )
+    player_intervention_indices: List[int] = Field(
+        default_factory=list,
+        description=(
+            "Indices in 'messages' after which the player is expected to respond or can intervene."
+        ),
+    )
+
+
+class NarratorInterventionEventModel(GameEventModel):
+    """Event containing narration addressed to the player or scene observations."""
+    type: Literal["narrator_intervention"] = Field(
+        "narrator_intervention", description="Type discriminator for this event."
+    )
+    messages: List[NarratorMessage] = Field(
+        default_factory=list,
+        description=(
+            "Ordered narration messages. Spoken entries address the player "
+            "directly while observations simply describe the scene."
+        ),
+    )
+
+
+class CutsceneFrameModel(BaseModel):
+    """Single frame within a cutscene."""
+    image_path: Optional[str] = Field(
+        None, description="Path to the image shown during this frame."
+    )
+    narrator_messages: List[NarratorMessage] = Field(
+        default_factory=list,
+        description="Narrator lines for this frame.",
+    )
+    npc_messages: List[NPCMessage] = Field(
+        default_factory=list,
+        description="NPC dialogue or actions for this frame.",
+    )
+
+
+class CutsceneEventModel(GameEventModel):
+    """Cinematic event composed of multiple frames."""
+    type: Literal["cutscene"] = Field(
+        "cutscene", description="Type discriminator for this event."
+    )
+    frames: List[CutsceneFrameModel] = Field(
+        default_factory=list,
+        description="Ordered sequence of frames composing the cutscene.",
+    )


### PR DESCRIPTION
## Summary
- rename event schemas to end in `Model`
- build domain wrappers for game event schemas
- base `BaseGameEvent` for domain classes
- clarify narrator spoken vs observation messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849b503c934832e8618cf4c3d4b2ce6