### PR TITLE
Refactor narrative structure models

### DIFF
--- a/backend/core_game/narrative/schemas.py
+++ b/backend/core_game/narrative/schemas.py
@@ -26,22 +26,46 @@ class FailureConditionModel(BaseModel):
     is_active: bool = Field(False, description="Indicates whether this failure condition has been fully triggered (risk level reached 100) and the narrative has failed as a result.")
     risk_triggered_beats: List[RiskTriggeredBeats] = Field(default_factory=list, description="List of risk level ranges mapped to narrative beats that should be triggered when the risk is within those ranges.")
 
-class NarrativeStageModel(BaseModel):
-    """Represents a stage in the narrative structure."""
-    name: str = Field(..., description="Stage name e.g. Introductio, climax, etc.")
-    narrative_objectives: str = Field(..., description="General objectives for this narrative stage, e.g., introducing characters, presenting conflicts, revealing the world, etc.")
-    stage_beats: List[NarrativeBeatModel] = Field(default_factory=list, description="Available narrative beats in the stage")
+class NarrativeStageTypeModel(BaseModel):
+    """Defines a stage in a narrative structure type (static info only)."""
+    name: str = Field(..., description="Stage name e.g. Introduction, climax, etc.")
+    narrative_objectives: str = Field(
+        ..., description="General objectives for this stage, e.g., introducing characters, presenting conflicts, revealing the world, etc."
+    )
+
+
+class NarrativeStageModel(NarrativeStageTypeModel):
+    """Represents a stage in an active narrative structure with beats."""
+    stage_beats: List[NarrativeBeatModel] = Field(
+        default_factory=list, description="Available narrative beats in the stage"
+    )
+
+class NarrativeStructureTypeModel(BaseModel):
+    """Static definition of a narrative structure without concrete beats."""
+    name: str = Field(..., description="Name of the narrative structure e.g. 5 act, Hero's journey")
+    description: str = Field(..., description="General description of the narrative structure and its logic.")
+    orientative_use_cases: str = Field(
+        ..., description="Typical use cases for this structure (genres or tones where it works well)."
+    )
+    stages: List[NarrativeStageTypeModel] = Field(
+        default_factory=list, description="Ordered stages that define this structure"
+    )
+
 
 class NarrativeStructureModel(BaseModel):
-    """Represents a commonly used narrative structure."""
-    name: str = Field(...,description="Name of the narrative structure e.g. 5 act, Heros journey")
-    description: str = Field(..., description="General description of the narrative structure and its logic.")
-    orientative_use_cases: str = Field(..., description="Typical use cases for this narrative structure (e.g., genres or narrative tones where it works well).")
-    stages: List[NarrativeStageModel] = Field(default_factory=list, description="Sorted stages of the narrative structure")
+    """Active narrative structure that contains dynamic beats."""
+    structure_type: NarrativeStructureTypeModel = Field(
+        ..., description="Reference to the static narrative structure definition."
+    )
+    stages: List[NarrativeStageModel] = Field(
+        default_factory=list, description="Stages of this structure with their narrative beats"
+    )
 
 class NarrativeStateModel(BaseModel):
     """Tracks the state of the plot, goals, and progression."""
     main_goal: Optional[GoalModel] = Field(None, description="The main goal of the narrative.")
     failure_conditions: List[FailureConditionModel] = Field(default_factory=list, description="List of failure conditions.")
     current_stage_index: Optional[int] = Field(0, description="Index of the currently active narrative stage.")
-    narrative_structure: NarrativeStructureModel = Field(...,description="Narrative structure selected for the narrative.")
+    narrative_structure: NarrativeStructureModel = Field(
+        ..., description="Narrative structure selected for the narrative."
+    )

--- a/backend/core_game/narrative/structures.py
+++ b/backend/core_game/narrative/structures.py
@@ -1,322 +1,294 @@
-from core_game.narrative.schemas import NarrativeStructureModel, NarrativeStageModel
+from core_game.narrative.schemas import (
+    NarrativeStructureTypeModel,
+    NarrativeStageTypeModel,
+)
 
-FIVE_ACT_STRUCTURE = NarrativeStructureModel(
+FIVE_ACT_STRUCTURE = NarrativeStructureTypeModel(
     name="Five Act Structure",
     description="A well-balanced narrative structure divided into five phases. Allows for gradual build-up of tension, multiple turning points, and a strong climactic resolution. Offers more granularity than the classic three-act model.",
     orientative_use_cases="Ideal for games where controlled pacing and gradual narrative escalation are desired. Useful for political intrigue, complex mysteries, relationship-driven stories, and character-centric drama.",
     stages=[
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Introduction",
             narrative_objectives="Present the world, main characters, and initial situation.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Initial Development",
             narrative_objectives="Introduce conflicts, obstacles, and deepen character relationships.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Advanced Development",
             narrative_objectives="Escalate conflicts, introduce new information or twists.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Climax",
             narrative_objectives="Bring key conflicts to a head. Force critical decisions.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Resolution",
             narrative_objectives="Resolve main conflicts, show consequences of decisions.",
-            stage_beats=[]
         ),
     ]
 )
 
-THREE_ACT_STRUCTURE = NarrativeStructureModel(
+THREE_ACT_STRUCTURE = NarrativeStructureTypeModel(
     name="Three Act Structure",
     description="A simple and versatile narrative structure divided into three main phases: setup, confrontation, and resolution. Provides a clear progression arc while allowing flexibility in pacing and tone.",
     orientative_use_cases="Ideal for flexible narrative-driven games where a balance between player agency and structured progression is desired. Works well for mysteries, political intrigue, adventure, and hybrid genres.",
     stages=[
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Introduction",
             narrative_objectives="Present the world, the main characters, the initial situation and set up both the main goal and the failure conditions.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Development",
             narrative_objectives="Advance the narrative towards the goal, introduce obstacles and complications, grow the risk level, force decisions.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Resolution",
             narrative_objectives="Bring the main goal and failure condition to resolution, close key narrative threads, present the final state of the world.",
-            stage_beats=[]
         ),
     ]
 )
 
-HEROS_JOURNEY_STRUCTURE = NarrativeStructureModel(
+HEROS_JOURNEY_STRUCTURE = NarrativeStructureTypeModel(
     name="Hero’s Journey",
     description="A classic narrative structure centered around a transformative journey. The player progresses through distinct phases of growth, challenge, and resolution. Encourages strong character arcs and emotional engagement.",
     orientative_use_cases="Ideal for character-driven narratives where the player undertakes a personal journey or quest. Supports both epic fantasy, mystery, and more intimate human stories with transformational arcs.",
     stages=[
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Ordinary World",
             narrative_objectives="Introduce the world, current status quo, and main characters. Show the player's ordinary life before the adventure.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Call to Adventure",
             narrative_objectives="Introduce the main goal and the reason why the player should pursue it. Increase narrative tension.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Crossing the Threshold",
             narrative_objectives="The player crosses into the new narrative space. The world reacts to this change. Initial real consequences appear.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Trials and Allies",
             narrative_objectives="Introduce challenges and secondary goals. Allow the player to build relationships, alliances, and knowledge.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Approach to the Inmost Cave",
             narrative_objectives="Build tension towards the main climax. Force the player to confront difficult choices or learn important truths.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Ordeal / Climax",
             narrative_objectives="Confront the main obstacle or enemy. Allow the player to resolve the primary narrative arc.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Reward and Return",
             narrative_objectives="Reward the player. Let the world reflect the impact of the player's decisions. Allow room for a potential new arc.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Resolution",
             narrative_objectives="Tie up loose ends. Reflect on how the world and characters have changed. Optionally, set up new possible adventures.",
-            stage_beats=[]
         ),
     ]
 )
 
-TENSION_DISCOVERY_STRUCTURE = NarrativeStructureModel(
+TENSION_DISCOVERY_STRUCTURE = NarrativeStructureTypeModel(
     name="Tension & Discovery Arc",
     description="A narrative structure focused on building tension progressively while allowing the player to discover key elements of the world and the plot. Balances structured escalation with periods of free exploration and relationship building.",
     orientative_use_cases="Ideal for stories where mystery, gradual worldbuilding, and mounting tension are central. Supports both linear and emergent narratives where pacing and atmosphere are key components.",
     stages=[
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="World Establishment",
             narrative_objectives="Establish the tone, rules of the world, and key factions or characters.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Initial Discovery",
             narrative_objectives="Let the player uncover initial information, mysteries or conflicts.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="First Conflicts",
             narrative_objectives="Present the player with first meaningful conflicts or dilemmas. Force some initial choices.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Tension Building",
             narrative_objectives="Introduce layers of mystery and escalating stakes. The player should feel the situation is getting more complex.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Free Development",
             narrative_objectives="Allow the player to freely pursue side goals, explore relationships, gather knowledge or power.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Escalation to Climax",
             narrative_objectives="Drive the narrative towards a point of maximum tension. Events converge towards the main goal or a decisive moment.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Climax and Resolution",
             narrative_objectives="Conclude the main narrative arcs, resolve major conflicts.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Epilogue and World State",
             narrative_objectives="Reflect on how the player's actions changed the world. Show consequences and possible new threads.",
-            stage_beats=[]
         ),
     ]
 )
 
-BRANCHING_STORY_STRUCTURE = NarrativeStructureModel(
+BRANCHING_STORY_STRUCTURE = NarrativeStructureTypeModel(
     name="Branching Story Structure",
     description="A narrative structure where the player's decisions cause the story to branch into distinct paths, leading to multiple possible developments and outcomes. The narrative adapts dynamically to player agency, offering replayability and divergent experiences.",
     orientative_use_cases="Suitable for experiences where player choice and consequence are central. Encourages exploration of different narrative possibilities and supports non-linear storytelling.",
     stages=[
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Introduction and Premise",
             narrative_objectives="Establish the setting, main goal, and present the initial conflict or mystery.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="First Critical Choice",
             narrative_objectives="Present a choice that will split the narrative into different possible paths.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Branched Development",
             narrative_objectives="Develop the chosen path with unique narrative beats, characters, and events.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Second Critical Choice",
             narrative_objectives="Present another major choice, possibly within the current path or re-aligning paths.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Resonance and Consequences",
             narrative_objectives="Have the world and characters react to the player's cumulative choices.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Multiple Climaxes",
             narrative_objectives="Reach different climaxes or narrative resolutions depending on the player's path.",
-            stage_beats=[]
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Adaptive Epilogue",
             narrative_objectives="Show an epilogue that reflects the player's path and choices throughout the story.",
-            stage_beats=[]
         ),
     ]
 )
 
-MYSTERY_STRUCTURE = NarrativeStructureModel(
+MYSTERY_STRUCTURE = NarrativeStructureTypeModel(
     name="Mystery Investigation",
     description="A narrative structure centered around the gradual discovery of information, where the player investigates a mystery through exploration, deduction, and interaction. The narrative unfolds as the player uncovers clues and navigates misdirection.",
     orientative_use_cases="Useful for narrative experiences focused on investigation, discovery, and tension, where the player progressively reconstructs hidden truths through their actions.",
     stages=[
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Mystery Setup",
             narrative_objectives="Introduce the central mystery or crime, the initial setting, and key characters."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Clue Discovery",
             narrative_objectives="Guide the player through finding clues and gathering information about the mystery."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Red Herrings",
             narrative_objectives="Introduce misleading clues and narrative twists to challenge the player's understanding."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Major Revelations",
             narrative_objectives="Reveal key pieces of the puzzle that change the player's perspective on the mystery."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Confrontation",
             narrative_objectives="Lead to a direct confrontation with the antagonist or a resolution of the mystery."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Resolution",
             narrative_objectives="Conclude the mystery and show the aftermath of the player's choices."
         ),
     ]
 )
 
-FACTION_CONFLICT_STRUCTURE = NarrativeStructureModel(
+FACTION_CONFLICT_STRUCTURE = NarrativeStructureTypeModel(
     name="Faction Conflict",
     description="A narrative structure centered around conflicts between multiple factions or groups, where the player's choices influence the balance of power and the ultimate outcome of the world.",
     orientative_use_cases="Suitable for narrative experiences where shifting alliances, moral ambiguity, and complex power dynamics are key drivers of the story. Encourages emergent outcomes and reactive worldbuilding.",
     stages=[
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="World and Factions Introduction",
             narrative_objectives="Introduce the world, the factions, and their main conflicts or goals."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Rising Tensions",
             narrative_objectives="Escalate conflicts between factions and present dilemmas to the player."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Player Influence",
             narrative_objectives="Allow the player to take actions that shift the balance between factions."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Conflict Climax",
             narrative_objectives="Reach a major turning point where faction conflicts culminate in significant events."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="New Stability",
             narrative_objectives="Establish a new world state based on the outcomes of the player's actions."
         ),
     ]
 )
 
-SANDBOX_STRUCTURE = NarrativeStructureModel(
+SANDBOX_STRUCTURE = NarrativeStructureTypeModel(
     name="Sandbox Driven",
     description="An open, player-driven narrative structure where the world is highly reactive and the player has significant agency. The narrative emerges organically from player choices and interactions with the world, rather than following a tightly scripted path.",
     orientative_use_cases="Suitable for narrative experiences focused on player agency and emergent storytelling, where the player shapes the narrative through free exploration and interaction rather than following a linear storyline.",
     stages=[
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="World Setup",
             narrative_objectives="Establish the world and its initial conditions, key locations, and characters."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="First Opportunities",
             narrative_objectives="Present initial opportunities and allow the player to explore freely."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="World Reactivity",
             narrative_objectives="Have the world and factions react dynamically to the player's choices."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Emerging Plotlines",
             narrative_objectives="Let new plotlines and conflicts emerge based on the player's interactions."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Player-Driven Climax",
             narrative_objectives="Build toward a climax or major world change influenced by the player's actions."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Outcome and Epilogue",
             narrative_objectives="Reflect on the player's impact on the world and wrap up active plotlines."
         ),
     ]
 )
 
-TENSION_RELEASE_STRUCTURE = NarrativeStructureModel(
+TENSION_RELEASE_STRUCTURE = NarrativeStructureTypeModel(
     name="Tension / Release Loop",
     description="A cyclical narrative structure that alternates between building tension and providing emotional release, creating a rhythm that keeps the player engaged.",
     orientative_use_cases="Works well in thriller, horror, mystery, adventure, and action-driven stories where pacing and emotional modulation are key.",
     stages=[
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Initial Calm",
             narrative_objectives="Introduce the setting and main characters in a relatively safe and calm context."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="First Tension Build-Up",
             narrative_objectives="Introduce initial conflicts, dangers, or mysteries that begin to create tension."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="First Release",
             narrative_objectives="Provide a partial resolution or relief that gives the player a sense of progress and control."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Second Tension Build-Up",
             narrative_objectives="Escalate the stakes, introduce new dangers, or deepen existing conflicts."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Second Release",
             narrative_objectives="Allow the player to achieve significant progress or resolve key conflicts, providing emotional release."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Final Tension Climax",
             narrative_objectives="Reach the highest point of narrative tension, where the main conflicts are at their peak."
         ),
-        NarrativeStageModel(
+        NarrativeStageTypeModel(
             name="Final Resolution",
             narrative_objectives="Resolve the central conflicts, reward the player with closure, and reflect on the outcome."
         ),


### PR DESCRIPTION
## Summary
- split static narrative structure types from dynamic narrative structures
- update schema classes accordingly
- use the new types when defining available narrative structures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd81a1cd8832eba2d7d924ff40be2