### PR TITLE
Add justification for narrative structure choice

### DIFF
--- a/backend/subsystems/generation/prompts/select_narrative_structure.py
+++ b/backend/subsystems/generation/prompts/select_narrative_structure.py
@@ -7,7 +7,7 @@ SYSTEM_PROMPT = """
 You are a Narrative Design Assistant for an interactive videogame. User will provide you with a conceptual idea of the narrative world and the main goal the player has in this world. Choose the most appropriate narrative structure type for the game story.
 You may use tools to inspect the available structures before making your decision. Only use as many tool calls as are strictly necessary to ensure your decision is well-informed.
 After using a tool you will receive an observation of the result of that tool.
-When sure about your decision, call `select_narrative_structure` with the id of your choice.
+When sure about your decision, call `select_narrative_structure` with a short justification of why you picked it and the id of your choice.
 Available structures (name and description): {structure_names}
 """
 

--- a/backend/subsystems/generation/schemas/graph_state.py
+++ b/backend/subsystems/generation/schemas/graph_state.py
@@ -23,3 +23,4 @@ class GenerationGraphState(BaseModel):
     max_structure_selection_reason_iterations: int = Field(default=4, description="Maximum iterations to reason to select a structure")
     max_structure_forced_selection_iterations: int = Field(default=3, description="Maximum attempts to select a structure")
     selected_structure: Optional[NarrativeStructureTypeModel] = Field(default=None, description="Narrative structure selected by the agent")
+    structure_selection_justification: Optional[str] = Field(default=None, description="Justification of why the selected structure was chosen")

--- a/backend/subsystems/generation/tools/narrative_structure_selection_tools.py
+++ b/backend/subsystems/generation/tools/narrative_structure_selection_tools.py
@@ -11,14 +11,15 @@ from subsystems.generation.schemas.graph_state import GenerationGraphState
 AVAILABLE_STRUCTURES_BY_ID = {s.id: s for s in AVAILABLE_NARRATIVE_STRUCTURES}
 
 class ToolSelectStructureArgs(BaseModel):
+    justification: str = Field(..., description="Short explanation of why this structure is chosen")
     structure_id: str = Field(..., description="ID of the narrative structure to select")
-    tool_call_id: Annotated[str, InjectedToolCallId] 
+    tool_call_id: Annotated[str, InjectedToolCallId]
 
 class ToolGetStructureInfoArgs(BaseModel):
     structure_id: str = Field(..., description="ID of the structure")
 
 @tool(args_schema=ToolSelectStructureArgs)
-def select_narrative_structure(structure_id: str, tool_call_id: Annotated[str, InjectedToolCallId]) -> Command:
+def select_narrative_structure(justification: str, structure_id: str, tool_call_id: Annotated[str, InjectedToolCallId]) -> Command:
     """Select one of the available narrative structures by its id."""
     struct = AVAILABLE_STRUCTURES_BY_ID.get(structure_id)
     if struct is None:
@@ -34,6 +35,7 @@ def select_narrative_structure(structure_id: str, tool_call_id: Annotated[str, I
     else:
         return Command(update={
             "selected_structure": struct,
+            "structure_selection_justification": justification,
             # update the message history
             "structure_selection_messages": [
                 ToolMessage(


### PR DESCRIPTION
## Summary
- require a justification when selecting a narrative structure
- store the justification in `GenerationGraphState`
- adjust the system prompt accordingly
- take justification as the first argument when calling `select_narrative_structure`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c367c9bdc832e8a0336e8df1021fa