### PR TITLE
Clarify modification tool behavior for player

### DIFF
--- a/backend/subsystems/agents/character_cast/schemas/simulated_characters.py
+++ b/backend/subsystems/agents/character_cast/schemas/simulated_characters.py
@@ -11,6 +11,7 @@ from core_game.character.schemas import (
     KnowledgeModel,
     DynamicStateModel,
     NarrativeWeightModel,
+    NarrativePurposeModel,
     NonPlayerCharacterModel,
     PlayerCharacterModel,
     CharacterBaseModel,
@@ -28,14 +29,220 @@ class CreateNPCArgs(BaseModel):
     narrative: NarrativeWeightModel = PydanticField(..., description="Narrative role and importance")
 
 
+class CreatePlayerArgs(BaseModel):
+    """Arguments required to create the player character."""
+    identity: IdentityModel = PydanticField(..., description="Full identity information")
+    physical: PhysicalAttributesModel = PydanticField(..., description="Full physical description")
+    psychological: PsychologicalAttributesModel = PydanticField(..., description="Detailed psychological profile")
+    knowledge: KnowledgeModel = PydanticField(default_factory=KnowledgeModel, description="Initial knowledge state")
+    present_in_scenario: str = PydanticField(..., description="ID of the scenario where the player starts")
+
+
 class ModifyCharacterArgs(BaseModel):
-    character_id: str = PydanticField(..., description="ID of the character to modify")
+    """Arguments for basic modifications valid for NPCs and the player."""
+
+    character_id: str = PydanticField(
+        ...,
+        description="ID of the character (NPC or player) to modify",
+    )
+    new_full_name: Optional[str] = PydanticField(
+        None, description="New full name"
+    )
+    new_personality_summary: Optional[str] = PydanticField(
+        None, description="New personality summary"
+    )
+
+
+class ModifyIdentityArgs(BaseModel):
+    """Arguments for updating identity attributes on NPCs or the player."""
+
+    character_id: str = PydanticField(
+        ...,
+        description="ID of the character (NPC or player) to modify",
+    )
     new_full_name: Optional[str] = PydanticField(None, description="New full name")
+    new_alias: Optional[str] = PydanticField(None, description="New alias")
+    new_age: Optional[int] = PydanticField(None, description="New age")
+    new_gender: Optional[Literal["male", "female", "non-binary", "undefined", "other"]] = PydanticField(
+        None, description="New gender"
+    )
+    new_profession: Optional[str] = PydanticField(None, description="New profession")
+    new_species: Optional[str] = PydanticField(None, description="New species")
+    new_alignment: Optional[str] = PydanticField(None, description="New alignment")
+
+
+class ModifyPhysicalArgs(BaseModel):
+    """Arguments for updating physical attributes on NPCs or the player."""
+
+    character_id: str = PydanticField(
+        ...,
+        description="ID of the character (NPC or player) to modify",
+    )
+    new_appearance: Optional[str] = PydanticField(None, description="New appearance")
+    new_distinctive_features: Optional[List[str]] = PydanticField(
+        None, description="New distinctive features list"
+    )
+    new_clothing_style: Optional[str] = PydanticField(None, description="New clothing style")
+    new_characteristic_items: Optional[List[str]] = PydanticField(
+        None, description="New characteristic items list"
+    )
+
+
+class ModifyPsychologicalArgs(BaseModel):
+    """Arguments for updating psychological traits on NPCs or the player."""
+
+    character_id: str = PydanticField(
+        ...,
+        description="ID of the character (NPC or player) to modify",
+    )
     new_personality_summary: Optional[str] = PydanticField(None, description="New personality summary")
+    new_personality_tags: Optional[List[str]] = PydanticField(None, description="New personality tags")
+    new_motivations: Optional[List[str]] = PydanticField(None, description="New motivations")
+    new_values: Optional[List[str]] = PydanticField(None, description="New values")
+    new_fears_and_weaknesses: Optional[List[str]] = PydanticField(
+        None, description="New fears and weaknesses"
+    )
+    new_communication_style: Optional[str] = PydanticField(None, description="New communication style")
+    new_backstory: Optional[str] = PydanticField(None, description="New backstory")
+    new_quirks: Optional[List[str]] = PydanticField(None, description="New quirks list")
+
+
+class ModifyKnowledgeArgs(BaseModel):
+    """Arguments for updating knowledge on NPCs or the player."""
+
+    character_id: str = PydanticField(
+        ...,
+        description="ID of the character (NPC or player) to modify",
+    )
+    new_background_knowledge: Optional[List[str]] = PydanticField(None, description="New background knowledge")
+    new_acquired_knowledge: Optional[List[str]] = PydanticField(None, description="New acquired knowledge")
+
+
+class ModifyDynamicStateArgs(BaseModel):
+    """Arguments for updating an NPC's dynamic state. Does not work on the player."""
+
+    character_id: str = PydanticField(
+        ...,
+        description="ID of the NPC to modify; the player cannot be modified",
+    )
+    new_current_emotion: Optional[str] = PydanticField(None, description="New current emotion")
+    new_immediate_goal: Optional[str] = PydanticField(None, description="New immediate goal")
+
+
+class ModifyNarrativeArgs(BaseModel):
+    """Arguments for updating an NPC's narrative role. Does not work on the player."""
+
+    character_id: str = PydanticField(
+        ...,
+        description="ID of the NPC to modify; the player cannot be modified",
+    )
+    new_narrative_role: Optional[Literal["protagonist", "secondary", "extra", "antagonist", "ally", "informational figure"]] = PydanticField(
+        None, description="New narrative role"
+    )
+    new_current_narrative_importance: Optional[Literal["important", "secondary", "minor", "inactive"]] = PydanticField(
+        None, description="New narrative importance"
+    )
+    new_narrative_purposes: Optional[List[NarrativePurposeModel]] = PydanticField(
+        None, description="New narrative purposes"
+    )
 
 
 class DeleteCharacterArgs(BaseModel):
-    character_id: str = PydanticField(..., description="ID of the character to delete")
+    """Arguments for deleting an NPC. The player cannot be deleted."""
+
+    character_id: str = PydanticField(
+        ...,
+        description="ID of the NPC to delete. The player character cannot be deleted.",
+    )
+
+
+class PlaceCharacterArgs(BaseModel):
+    """Arguments for placing a character in a scenario.
+
+    If the character is already in another scenario, it will be moved to the
+    specified one. This works for both NPCs and the player.
+    """
+
+    character_id: str = PydanticField(
+        ..., description="ID of the character to place or move"
+    )
+    new_scene_id: str = PydanticField(
+        ...,
+        description=(
+            "ID of the destination scenario. If the character was already in a"
+            " scene, it will be relocated here"
+        ),
+    )
+
+
+class RemoveCharacterFromScenarioArgs(BaseModel):
+    """Arguments for removing a character from its current scenario.
+
+    Only NPCs can be unplaced; the player must always belong to a scenario.
+    """
+
+    character_id: str = PydanticField(
+        ...,
+        description="ID of the NPC to unplace; the player cannot be removed from its scenario.",
+    )
+
+
+class ListCharactersArgs(BaseModel):
+    """Arguments for listing or filtering characters."""
+    attribute_to_filter: Optional[Literal[
+        "narrative_role",
+        "current_narrative_importance",
+        "species",
+        "profession",
+        "gender",
+        "alias",
+        "name_contains",
+    ]] = PydanticField(
+        default=None,
+        description="Optional attribute to filter by",
+    )
+    value_to_match: Optional[str] = PydanticField(
+        default=None,
+        description="Value that the attribute should match or contain",
+    )
+    max_results: Optional[int] = PydanticField(
+        default=10,
+        description="Maximum number of characters to list when filtering",
+    )
+    list_identity: bool = PydanticField(
+        default=False,
+        description="Include full identity fields when listing",
+    )
+    list_physical: bool = PydanticField(
+        default=False,
+        description="Include physical attributes when listing",
+    )
+    list_psychological: bool = PydanticField(
+        default=False,
+        description="Include psychological traits when listing",
+    )
+    list_knowledge: bool = PydanticField(
+        default=False,
+        description="Include knowledge fields when listing",
+    )
+    list_dynamic_state: bool = PydanticField(
+        default=False,
+        description="Include dynamic state when listing",
+    )
+    list_narrative: bool = PydanticField(
+        default=False,
+        description="Include narrative attributes when listing",
+    )
+
+
+class GetCharacterDetailsArgs(BaseModel):
+    """Arguments for retrieving a character's full details."""
+    character_id: str = PydanticField(..., description="ID of the character")
+
+
+class GetPlayerDetailsArgs(BaseModel):
+    """Arguments for retrieving details of the player character."""
+    pass
 
 
 class SimulatedCharactersModel(BaseModel):
@@ -43,6 +250,7 @@ class SimulatedCharactersModel(BaseModel):
 
     simulated_characters: Dict[str, CharacterBaseModel] = PydanticField(default_factory=dict)
     deleted_characters: Dict[str, CharacterBaseModel] = PydanticField(default_factory=dict)
+    player_character: Optional[PlayerCharacterModel] = PydanticField(default=None)
     executor_applied_operations_log: List[Dict[str, Any]] = PydanticField(default_factory=list)
 
     validator_applied_operations_log: List[Dict[str, Any]] = PydanticField(default_factory=list)
@@ -88,4 +296,165 @@ class SimulatedCharactersModel(BaseModel):
         if not self.simulated_characters:
             return "No characters created yet."
         return "Characters: " + ", ".join(f"{c.identity.full_name}({cid})" for cid, c in self.simulated_characters.items())
+
+    def list_characters(self, args_model: ListCharactersArgs) -> str:
+        """(QUERY tool) Lists characters optionally filtered by an attribute."""
+        if not self.simulated_characters:
+            return self._log_and_summarize(
+                "list_characters",
+                args_model,
+                True,
+                "The cast is currently empty.",
+            )
+
+        matches: List[str] = []
+        for char in self.simulated_characters.values():
+            if args_model.attribute_to_filter and args_model.value_to_match:
+                value = ""
+                match_val = args_model.value_to_match.lower()
+                if args_model.attribute_to_filter == "narrative_role":
+                    if isinstance(char, NonPlayerCharacterModel):
+                        value = char.narrative.narrative_role
+                elif args_model.attribute_to_filter == "current_narrative_importance":
+                    if isinstance(char, NonPlayerCharacterModel):
+                        value = char.narrative.current_narrative_importance
+                elif args_model.attribute_to_filter == "species":
+                    value = char.identity.species
+                elif args_model.attribute_to_filter == "profession":
+                    value = char.identity.profession
+                elif args_model.attribute_to_filter == "gender":
+                    value = char.identity.gender
+                elif args_model.attribute_to_filter == "alias":
+                    value = char.identity.alias or ""
+                elif args_model.attribute_to_filter == "name_contains":
+                    value = char.identity.full_name
+                if match_val not in str(value).lower():
+                    continue
+
+            summary = f"- ID: {char.id}, Name: '{char.identity.full_name}', Type: {char.type}"
+            role = (
+                char.narrative.narrative_role
+                if isinstance(char, NonPlayerCharacterModel)
+                else "N/A"
+            )
+            summary += f", Role: {role}"
+            if args_model.list_identity:
+                summary += f", identity={char.identity.model_dump()}"
+            if args_model.list_physical:
+                summary += f", physical={char.physical.model_dump()}"
+            if args_model.list_psychological:
+                summary += f", psychological={char.psychological.model_dump()}"
+            if args_model.list_knowledge:
+                summary += f", knowledge={char.knowledge.model_dump()}"
+            if isinstance(char, NonPlayerCharacterModel) and args_model.list_dynamic_state:
+                summary += f", dynamic_state={char.dynamic_state.model_dump()}"
+            if isinstance(char, NonPlayerCharacterModel) and args_model.list_narrative:
+                summary += f", narrative={char.narrative.model_dump()}"
+
+            matches.append(summary)
+            if args_model.max_results and len(matches) >= args_model.max_results:
+                break
+
+        if not matches:
+            return self._log_and_summarize(
+                "list_characters",
+                args_model,
+                True,
+                "No characters found matching the criteria.",
+            )
+
+        return self._log_and_summarize(
+            "list_characters",
+            args_model,
+            True,
+            "\n".join(matches),
+        )
+
+    def create_player(self, args_model: CreatePlayerArgs) -> str:
+        """(MODIFICATION tool) Create the player character."""
+        if self.player_character is not None:
+            return self._log_and_summarize(
+                "create_player",
+                args_model,
+                False,
+                "Error: Player already exists.",
+            )
+
+        new_id = self.generate_sequential_character_id(list(self.simulated_characters.keys()))
+        player = PlayerCharacterModel(
+            id=new_id,
+            identity=args_model.identity,
+            physical=args_model.physical,
+            psychological=args_model.psychological,
+            knowledge=args_model.knowledge,
+            present_in_scenario=args_model.present_in_scenario,
+        )
+
+        self.player_character = player
+        self.simulated_characters[new_id] = player
+
+        return self._log_and_summarize(
+            "create_player",
+            args_model,
+            True,
+            f"Player '{player.identity.full_name}' created with id {new_id} in scene {args_model.present_in_scenario}.",
+        )
+
+    def get_player_details(self, args_model: GetPlayerDetailsArgs) -> str:
+        """(QUERY tool) Get details about the player character."""
+        if self.player_character is None:
+            return self._log_and_summarize(
+                "get_player_details",
+                args_model,
+                False,
+                "Error: Player character does not exist.",
+            )
+
+        player = self.player_character
+        details = [
+            f"ID: {player.id}",
+            f"Name: {player.identity.full_name}",
+            f"Scene: {player.present_in_scenario}",
+            f"Profession: {player.identity.profession}",
+            f"Species: {player.identity.species}",
+        ]
+        return self._log_and_summarize(
+            "get_player_details",
+            args_model,
+            True,
+            "\n".join(details),
+        )
+
+    def get_character_details(self, args_model: GetCharacterDetailsArgs) -> str:
+        """(QUERY tool) Returns detailed information for a character."""
+        char = self.simulated_characters.get(args_model.character_id)
+        if not char:
+            return self._log_and_summarize(
+                "get_character_details",
+                args_model,
+                False,
+                f"Error: Character ID '{args_model.character_id}' not found.",
+            )
+
+        role = (
+            char.narrative.narrative_role
+            if isinstance(char, NonPlayerCharacterModel)
+            else "N/A"
+        )
+        details = [
+            f"ID: {char.id}",
+            f"Name: {char.identity.full_name}",
+            f"Species: {char.identity.species}",
+            f"Profession: {char.identity.profession}",
+            f"Narrative Role: {role}",
+            f"Personality: {char.psychological.personality_summary}",
+        ]
+        return self._log_and_summarize(
+            "get_character_details",
+            args_model,
+            True,
+            "\n".join(details),
+        )
+
+
 

--- a/backend/subsystems/agents/character_cast/tools/character_tools.py
+++ b/backend/subsystems/agents/character_cast/tools/character_tools.py
@@ -13,18 +13,73 @@ from core_game.character.schemas import (
     DynamicStateModel,
     NarrativeWeightModel,
     NonPlayerCharacterModel,
+    PlayerCharacterModel,
 )
 
 from ..schemas.simulated_characters import (
     SimulatedCharactersModel,
     CreateNPCArgs,
     ModifyCharacterArgs,
+    ModifyIdentityArgs,
+    ModifyPhysicalArgs,
+    ModifyPsychologicalArgs,
+    ModifyKnowledgeArgs,
+    ModifyDynamicStateArgs,
+    ModifyNarrativeArgs,
     DeleteCharacterArgs,
+    PlaceCharacterArgs,
+    RemoveCharacterFromScenarioArgs,
+    ListCharactersArgs,
+    GetCharacterDetailsArgs,
+    CreatePlayerArgs,
+    GetPlayerDetailsArgs,
 )
 
 
 # --- Tools Schemas -- (adding the injected simulated map)
 class ToolCreateScenarioArgs(CreateNPCArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolModifyCharacterArgs(ModifyCharacterArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolModifyIdentityArgs(ModifyIdentityArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolModifyPhysicalArgs(ModifyPhysicalArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolModifyPsychologicalArgs(ModifyPsychologicalArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolModifyKnowledgeArgs(ModifyKnowledgeArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolModifyDynamicStateArgs(ModifyDynamicStateArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolModifyNarrativeArgs(ModifyNarrativeArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolDeleteCharacterArgs(DeleteCharacterArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolPlaceCharacterArgs(PlaceCharacterArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolRemoveCharacterFromScenarioArgs(RemoveCharacterFromScenarioArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolListCharactersArgs(ListCharactersArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolGetCharacterDetailsArgs(GetCharacterDetailsArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolCreatePlayerArgs(CreatePlayerArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolGetPlayerDetailsArgs(GetPlayerDetailsArgs):
     simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
 
 
@@ -85,8 +140,571 @@ def finalize_simulation(
     )
 
 
+@tool(args_schema=ToolCreatePlayerArgs)
+def create_player(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    identity: IdentityModel,
+    physical: PhysicalAttributesModel,
+    psychological: PsychologicalAttributesModel,
+    present_in_scenario: str,
+    knowledge: KnowledgeModel = KnowledgeModel(),
+) -> str:
+    """(MODIFICATION tool) Create the player character."""
+    args_model = CreatePlayerArgs(
+        identity=identity,
+        physical=physical,
+        psychological=psychological,
+        knowledge=knowledge,
+        present_in_scenario=present_in_scenario,
+    )
+    return simulated_characters_state.create_player(args_model=args_model)
+
+
+@tool(args_schema=ToolGetPlayerDetailsArgs)
+def get_player_details(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+) -> str:
+    """(QUERY tool) Get details of the player character."""
+    return simulated_characters_state.get_player_details(args_model=GetPlayerDetailsArgs())
+
+
+@tool(args_schema=ToolListCharactersArgs)
+def list_characters(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    attribute_to_filter: Optional[str] = None,
+    value_to_match: Optional[str] = None,
+    max_results: Optional[int] = 10,
+    list_identity: bool = False,
+    list_physical: bool = False,
+    list_psychological: bool = False,
+    list_knowledge: bool = False,
+    list_dynamic_state: bool = False,
+    list_narrative: bool = False,
+) -> str:
+    """(QUERY tool) List characters optionally filtered by an attribute."""
+    args_model = ListCharactersArgs(
+        attribute_to_filter=attribute_to_filter,
+        value_to_match=value_to_match,
+        max_results=max_results,
+        list_identity=list_identity,
+        list_physical=list_physical,
+        list_psychological=list_psychological,
+        list_knowledge=list_knowledge,
+        list_dynamic_state=list_dynamic_state,
+        list_narrative=list_narrative,
+    )
+    return simulated_characters_state.list_characters(args_model=args_model)
+
+
+@tool(args_schema=ToolGetCharacterDetailsArgs)
+def get_character_details(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    character_id: str,
+) -> str:
+    """(QUERY tool) Get full details of a character."""
+    args_model = GetCharacterDetailsArgs(character_id=character_id)
+    return simulated_characters_state.get_character_details(args_model=args_model)
+
+
+@tool(args_schema=ToolModifyCharacterArgs)
+def modify_character(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    character_id: str,
+    new_full_name: Optional[str] = None,
+    new_personality_summary: Optional[str] = None,
+) -> str:
+    """(MODIFICATION tool) Modify a character's basic attributes."""
+
+    # Works on both NPCs and the player.
+    args_model = ModifyCharacterArgs(
+        character_id=character_id,
+        new_full_name=new_full_name,
+        new_personality_summary=new_personality_summary,
+    )
+
+    char = simulated_characters_state.simulated_characters.get(character_id)
+    if not char:
+        return simulated_characters_state._log_and_summarize(
+            "modify_character",
+            args_model,
+            False,
+            f"Error: Character ID '{character_id}' not found.",
+        )
+
+    updated_fields = []
+    if new_full_name is not None:
+        char.identity.full_name = new_full_name
+        updated_fields.append("full_name")
+    if new_personality_summary is not None:
+        char.psychological.personality_summary = new_personality_summary
+        updated_fields.append("personality_summary")
+
+    message = "No changes applied." if not updated_fields else f"Updated fields: {', '.join(updated_fields)}."
+    return simulated_characters_state._log_and_summarize(
+        "modify_character",
+        args_model,
+        True,
+        message,
+    )
+
+
+@tool(args_schema=ToolModifyIdentityArgs)
+def modify_identity(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    character_id: str,
+    new_full_name: Optional[str] = None,
+    new_alias: Optional[str] = None,
+    new_age: Optional[int] = None,
+    new_gender: Optional[str] = None,
+    new_profession: Optional[str] = None,
+    new_species: Optional[str] = None,
+    new_alignment: Optional[str] = None,
+) -> str:
+    """(MODIFICATION tool) Update identity attributes of a character."""
+
+    # Works for both NPCs and the player.
+    args_model = ModifyIdentityArgs(
+        character_id=character_id,
+        new_full_name=new_full_name,
+        new_alias=new_alias,
+        new_age=new_age,
+        new_gender=new_gender,
+        new_profession=new_profession,
+        new_species=new_species,
+        new_alignment=new_alignment,
+    )
+    char = simulated_characters_state.simulated_characters.get(character_id)
+    if not char:
+        return simulated_characters_state._log_and_summarize(
+            "modify_identity",
+            args_model,
+            False,
+            f"Error: Character ID '{character_id}' not found.",
+        )
+
+    updated_fields = []
+    if new_full_name is not None:
+        char.identity.full_name = new_full_name
+        updated_fields.append("full_name")
+    if new_alias is not None:
+        char.identity.alias = new_alias
+        updated_fields.append("alias")
+    if new_age is not None:
+        char.identity.age = new_age
+        updated_fields.append("age")
+    if new_gender is not None:
+        char.identity.gender = new_gender
+        updated_fields.append("gender")
+    if new_profession is not None:
+        char.identity.profession = new_profession
+        updated_fields.append("profession")
+    if new_species is not None:
+        char.identity.species = new_species
+        updated_fields.append("species")
+    if new_alignment is not None:
+        char.identity.alignment = new_alignment
+        updated_fields.append("alignment")
+
+    message = "No changes applied." if not updated_fields else f"Updated fields: {', '.join(updated_fields)}."
+    return simulated_characters_state._log_and_summarize(
+        "modify_identity",
+        args_model,
+        True,
+        message,
+    )
+
+
+@tool(args_schema=ToolModifyPhysicalArgs)
+def modify_physical(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    character_id: str,
+    new_appearance: Optional[str] = None,
+    new_distinctive_features: Optional[list] = None,
+    new_clothing_style: Optional[str] = None,
+    new_characteristic_items: Optional[list] = None,
+) -> str:
+    """(MODIFICATION tool) Update physical traits of a character."""
+
+    # Works for both NPCs and the player.
+    args_model = ModifyPhysicalArgs(
+        character_id=character_id,
+        new_appearance=new_appearance,
+        new_distinctive_features=new_distinctive_features,
+        new_clothing_style=new_clothing_style,
+        new_characteristic_items=new_characteristic_items,
+    )
+    char = simulated_characters_state.simulated_characters.get(character_id)
+    if not char:
+        return simulated_characters_state._log_and_summarize(
+            "modify_physical",
+            args_model,
+            False,
+            f"Error: Character ID '{character_id}' not found.",
+        )
+
+    updated_fields = []
+    if new_appearance is not None:
+        char.physical.appearance = new_appearance
+        updated_fields.append("appearance")
+    if new_distinctive_features is not None:
+        char.physical.distinctive_features = new_distinctive_features
+        updated_fields.append("distinctive_features")
+    if new_clothing_style is not None:
+        char.physical.clothing_style = new_clothing_style
+        updated_fields.append("clothing_style")
+    if new_characteristic_items is not None:
+        char.physical.characteristic_items = new_characteristic_items
+        updated_fields.append("characteristic_items")
+
+    message = "No changes applied." if not updated_fields else f"Updated fields: {', '.join(updated_fields)}."
+    return simulated_characters_state._log_and_summarize(
+        "modify_physical",
+        args_model,
+        True,
+        message,
+    )
+
+
+@tool(args_schema=ToolModifyPsychologicalArgs)
+def modify_psychological(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    character_id: str,
+    new_personality_summary: Optional[str] = None,
+    new_personality_tags: Optional[list] = None,
+    new_motivations: Optional[list] = None,
+    new_values: Optional[list] = None,
+    new_fears_and_weaknesses: Optional[list] = None,
+    new_communication_style: Optional[str] = None,
+    new_backstory: Optional[str] = None,
+    new_quirks: Optional[list] = None,
+) -> str:
+    """(MODIFICATION tool) Update psychological traits of a character."""
+
+    # Works for both NPCs and the player.
+    args_model = ModifyPsychologicalArgs(
+        character_id=character_id,
+        new_personality_summary=new_personality_summary,
+        new_personality_tags=new_personality_tags,
+        new_motivations=new_motivations,
+        new_values=new_values,
+        new_fears_and_weaknesses=new_fears_and_weaknesses,
+        new_communication_style=new_communication_style,
+        new_backstory=new_backstory,
+        new_quirks=new_quirks,
+    )
+    char = simulated_characters_state.simulated_characters.get(character_id)
+    if not char:
+        return simulated_characters_state._log_and_summarize(
+            "modify_psychological",
+            args_model,
+            False,
+            f"Error: Character ID '{character_id}' not found.",
+        )
+
+    updated_fields = []
+    if new_personality_summary is not None:
+        char.psychological.personality_summary = new_personality_summary
+        updated_fields.append("personality_summary")
+    if new_personality_tags is not None:
+        char.psychological.personality_tags = new_personality_tags
+        updated_fields.append("personality_tags")
+    if new_motivations is not None:
+        char.psychological.motivations = new_motivations
+        updated_fields.append("motivations")
+    if new_values is not None:
+        char.psychological.values = new_values
+        updated_fields.append("values")
+    if new_fears_and_weaknesses is not None:
+        char.psychological.fears_and_weaknesses = new_fears_and_weaknesses
+        updated_fields.append("fears_and_weaknesses")
+    if new_communication_style is not None:
+        char.psychological.communication_style = new_communication_style
+        updated_fields.append("communication_style")
+    if new_backstory is not None:
+        char.psychological.backstory = new_backstory
+        updated_fields.append("backstory")
+    if new_quirks is not None:
+        char.psychological.quirks = new_quirks
+        updated_fields.append("quirks")
+
+    message = "No changes applied." if not updated_fields else f"Updated fields: {', '.join(updated_fields)}."
+    return simulated_characters_state._log_and_summarize(
+        "modify_psychological",
+        args_model,
+        True,
+        message,
+    )
+
+
+@tool(args_schema=ToolModifyKnowledgeArgs)
+def modify_knowledge(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    character_id: str,
+    new_background_knowledge: Optional[list] = None,
+    new_acquired_knowledge: Optional[list] = None,
+) -> str:
+    """(MODIFICATION tool) Update a character's knowledge."""
+
+    # Works for both NPCs and the player.
+    args_model = ModifyKnowledgeArgs(
+        character_id=character_id,
+        new_background_knowledge=new_background_knowledge,
+        new_acquired_knowledge=new_acquired_knowledge,
+    )
+    char = simulated_characters_state.simulated_characters.get(character_id)
+    if not char:
+        return simulated_characters_state._log_and_summarize(
+            "modify_knowledge",
+            args_model,
+            False,
+            f"Error: Character ID '{character_id}' not found.",
+        )
+
+    updated_fields = []
+    if new_background_knowledge is not None:
+        char.knowledge.background_knowledge = new_background_knowledge
+        updated_fields.append("background_knowledge")
+    if new_acquired_knowledge is not None:
+        char.knowledge.acquired_knowledge = new_acquired_knowledge
+        updated_fields.append("acquired_knowledge")
+
+    message = "No changes applied." if not updated_fields else f"Updated fields: {', '.join(updated_fields)}."
+    return simulated_characters_state._log_and_summarize(
+        "modify_knowledge",
+        args_model,
+        True,
+        message,
+    )
+
+
+@tool(args_schema=ToolModifyDynamicStateArgs)
+def modify_dynamic_state(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    character_id: str,
+    new_current_emotion: Optional[str] = None,
+    new_immediate_goal: Optional[str] = None,
+) -> str:
+    """(MODIFICATION tool) Update an NPC's dynamic state."
+
+    This tool does not work on the player character.
+    """
+    args_model = ModifyDynamicStateArgs(
+        character_id=character_id,
+        new_current_emotion=new_current_emotion,
+        new_immediate_goal=new_immediate_goal,
+    )
+    char = simulated_characters_state.simulated_characters.get(character_id)
+    if not char:
+        return simulated_characters_state._log_and_summarize(
+            "modify_dynamic_state",
+            args_model,
+            False,
+            f"Error: Character ID '{character_id}' not found.",
+        )
+
+    if isinstance(char, PlayerCharacterModel):
+        return simulated_characters_state._log_and_summarize(
+            "modify_dynamic_state",
+            args_model,
+            False,
+            "Error: Cannot modify the player's dynamic state.",
+        )
+
+    updated_fields = []
+    if new_current_emotion is not None:
+        char.dynamic_state.current_emotion = new_current_emotion
+        updated_fields.append("current_emotion")
+    if new_immediate_goal is not None:
+        char.dynamic_state.immediate_goal = new_immediate_goal
+        updated_fields.append("immediate_goal")
+
+    message = "No changes applied." if not updated_fields else f"Updated fields: {', '.join(updated_fields)}."
+    return simulated_characters_state._log_and_summarize(
+        "modify_dynamic_state",
+        args_model,
+        True,
+        message,
+    )
+
+
+@tool(args_schema=ToolModifyNarrativeArgs)
+def modify_narrative(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    character_id: str,
+    new_narrative_role: Optional[str] = None,
+    new_current_narrative_importance: Optional[str] = None,
+    new_narrative_purposes: Optional[list] = None,
+) -> str:
+    """(MODIFICATION tool) Update an NPC's narrative attributes."
+
+    This tool cannot modify the player character.
+    """
+    args_model = ModifyNarrativeArgs(
+        character_id=character_id,
+        new_narrative_role=new_narrative_role,
+        new_current_narrative_importance=new_current_narrative_importance,
+        new_narrative_purposes=new_narrative_purposes,
+    )
+    char = simulated_characters_state.simulated_characters.get(character_id)
+    if not char:
+        return simulated_characters_state._log_and_summarize(
+            "modify_narrative",
+            args_model,
+            False,
+            f"Error: Character ID '{character_id}' not found.",
+        )
+
+    if isinstance(char, PlayerCharacterModel):
+        return simulated_characters_state._log_and_summarize(
+            "modify_narrative",
+            args_model,
+            False,
+            "Error: Cannot modify the player's narrative attributes.",
+        )
+
+    updated_fields = []
+    if new_narrative_role is not None:
+        char.narrative.narrative_role = new_narrative_role
+        updated_fields.append("narrative_role")
+    if new_current_narrative_importance is not None:
+        char.narrative.current_narrative_importance = new_current_narrative_importance
+        updated_fields.append("current_narrative_importance")
+    if new_narrative_purposes is not None:
+        char.narrative.narrative_purposes = new_narrative_purposes
+        updated_fields.append("narrative_purposes")
+
+    message = "No changes applied." if not updated_fields else f"Updated fields: {', '.join(updated_fields)}."
+    return simulated_characters_state._log_and_summarize(
+        "modify_narrative",
+        args_model,
+        True,
+        message,
+    )
+
+
+@tool(args_schema=ToolPlaceCharacterArgs)
+def place_character(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    character_id: str,
+    new_scene_id: str,
+) -> str:
+    """(MODIFICATION tool) Place a character into a scenario.
+
+    If the character is already in another scenario, it will be moved to the
+    provided one. Works on both NPCs and the player.
+    """
+
+    args_model = PlaceCharacterArgs(character_id=character_id, new_scene_id=new_scene_id)
+
+    char = simulated_characters_state.simulated_characters.get(character_id)
+    if not char:
+        return simulated_characters_state._log_and_summarize(
+            "place_character",
+            args_model,
+            False,
+            f"Error: Character ID '{character_id}' not found.",
+        )
+
+    previous_scene = char.present_in_scenario
+    char.present_in_scenario = new_scene_id
+    action = "moved" if previous_scene and previous_scene != new_scene_id else "placed"
+    return simulated_characters_state._log_and_summarize(
+        "place_character",
+        args_model,
+        True,
+        f"Character '{char.identity.full_name}' {action} to scene {new_scene_id}.",
+    )
+
+
+@tool(args_schema=ToolRemoveCharacterFromScenarioArgs)
+def remove_character_from_scenario(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    character_id: str,
+) -> str:
+    """(MODIFICATION tool) Remove an NPC from its current scenario.
+
+    The player cannot be removed from a scenario.
+    """
+
+    args_model = RemoveCharacterFromScenarioArgs(character_id=character_id)
+
+    char = simulated_characters_state.simulated_characters.get(character_id)
+    if not char:
+        return simulated_characters_state._log_and_summarize(
+            "remove_character_from_scenario",
+            args_model,
+            False,
+            f"Error: Character ID '{character_id}' not found.",
+        )
+
+    if isinstance(char, PlayerCharacterModel):
+        return simulated_characters_state._log_and_summarize(
+            "remove_character_from_scenario",
+            args_model,
+            False,
+            "Error: Cannot remove the player from a scenario.",
+        )
+
+    char.present_in_scenario = None
+    return simulated_characters_state._log_and_summarize(
+        "remove_character_from_scenario",
+        args_model,
+        True,
+        f"Character '{char.identity.full_name}' removed from its scenario.",
+    )
+
+
+@tool(args_schema=ToolDeleteCharacterArgs)
+def delete_character(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")],
+    character_id: str,
+) -> str:
+    """(MODIFICATION tool) Delete an NPC from the cast. The player cannot be deleted."""
+    args_model = DeleteCharacterArgs(character_id=character_id)
+
+    char = simulated_characters_state.simulated_characters.get(character_id)
+    if not char:
+        return simulated_characters_state._log_and_summarize(
+            "delete_character",
+            args_model,
+            False,
+            f"Error: Character ID '{character_id}' not found.",
+        )
+
+    if isinstance(char, PlayerCharacterModel):
+        return simulated_characters_state._log_and_summarize(
+            "delete_character",
+            args_model,
+            False,
+            "Error: Cannot delete the player character.",
+        )
+
+    simulated_characters_state.simulated_characters.pop(character_id)
+    simulated_characters_state.deleted_characters[character_id] = char
+    return simulated_characters_state._log_and_summarize(
+        "delete_character",
+        args_model,
+        True,
+        f"Character '{char.identity.full_name}' deleted.",
+    )
+
+
 EXECUTORTOOLS = [
     create_full_npc,
+    create_player,
+    list_characters,
+    get_player_details,
+    get_character_details,
+    modify_character,
+    modify_identity,
+    modify_physical,
+    modify_psychological,
+    modify_knowledge,
+    modify_dynamic_state,
+    modify_narrative,
+    place_character,
+    remove_character_from_scenario,
+    delete_character,
     finalize_simulation,
 ]
 

--- a/backend/tests/character_execution_tools_manual_test.py
+++ b/backend/tests/character_execution_tools_manual_test.py
@@ -9,14 +9,24 @@ from core_game.character.schemas import (
     PhysicalAttributesModel,
     PsychologicalAttributesModel,
     NarrativeWeightModel,
+    NarrativePurposeModel,
 )
 from subsystems.agents.character_cast.schemas.simulated_characters import (
     SimulatedCharactersModel,
-    CreateFullNPCArgs,
+    CreateNPCArgs,
+    CreatePlayerArgs,
 )
 from subsystems.agents.character_cast.tools.character_tools import (
     create_full_npc,
+    create_player,
+    place_character,
+    remove_character_from_scenario,
+    delete_character,
     list_characters,
+    get_player_details,
+    modify_identity,
+    modify_dynamic_state,
+    modify_narrative,
 )
 
 
@@ -34,8 +44,15 @@ if __name__ == "__main__":
 
     print_step("Create Characters")
 
-    char1_args = CreateFullNPCArgs(
-        identity=IdentityModel(full_name="Lia the Merchant", gender="female"),
+    char1_args = CreateNPCArgs(
+        identity=IdentityModel(
+            full_name="Lia the Merchant",
+            gender="female",
+            age=30,
+            profession="merchant",
+            species="human",
+            alignment="neutral",
+        ),
         physical=PhysicalAttributesModel(
             appearance="Short woman with sharp eyes",
             clothing_style="travel garb",
@@ -44,24 +61,41 @@ if __name__ == "__main__":
         ),
         psychological=PsychologicalAttributesModel(
             personality_summary="Shrewd yet kind-hearted",
+            personality_tags=["shrewd", "kind"],
+            motivations=["profit"],
+            values=["fairness"],
+            fears_and_weaknesses=[],
+            communication_style="direct",
             backstory="Former street orphan turned successful trader",
+            quirks=["hums while working"],
         ),
         narrative=NarrativeWeightModel(
             narrative_role="ally",
-            narrative_importance="secondary",
-            narrative_purpose=[],
+            current_narrative_importance="secondary",
+            narrative_purposes=[
+                NarrativePurposeModel(mission="support protagonist", is_hidden=False)
+            ],
         ),
     )
 
     print(
-        create_full_npc(
-            **char1_args.model_dump(),
-            simulated_characters_state=characters_state,
+        create_full_npc.invoke(
+            {
+                **char1_args.model_dump(),
+                "simulated_characters_state": characters_state,
+            }
         )
     )
 
-    char2_args = CreateFullNPCArgs(
-        identity=IdentityModel(full_name="Bran the Guard", gender="male"),
+    char2_args = CreateNPCArgs(
+        identity=IdentityModel(
+            full_name="Bran the Guard",
+            gender="male",
+            age=35,
+            profession="guard",
+            species="human",
+            alignment="lawful good",
+        ),
         physical=PhysicalAttributesModel(
             appearance="Tall and muscular",
             clothing_style="town guard uniform",
@@ -70,24 +104,177 @@ if __name__ == "__main__":
         ),
         psychological=PsychologicalAttributesModel(
             personality_summary="Loyal and steadfast",
+            personality_tags=["loyal"],
+            motivations=["duty"],
+            values=["honor"],
+            fears_and_weaknesses=[],
+            communication_style="formal",
             backstory="Veteran of border skirmishes",
+            quirks=["polishes armor obsessively"],
         ),
         narrative=NarrativeWeightModel(
-            narrative_role="support",
-            narrative_importance="secondary",
-            narrative_purpose=[],
+            narrative_role="ally",
+            current_narrative_importance="secondary",
+            narrative_purposes=[
+                NarrativePurposeModel(mission="defend town", is_hidden=False)
+            ],
         ),
     )
 
     print(
-        create_full_npc(
-            **char2_args.model_dump(),
-            simulated_characters_state=characters_state,
+        create_full_npc.invoke(
+            {
+                **char2_args.model_dump(),
+                "simulated_characters_state": characters_state,
+            }
+        )
+    )
+
+    print_step("Create Player")
+
+    player_args = CreatePlayerArgs(
+        identity=IdentityModel(
+            full_name="Arin the Wanderer",
+            gender="non-binary",
+            age=24,
+            profession="adventurer",
+            species="human",
+            alignment="chaotic good",
+        ),
+        physical=PhysicalAttributesModel(
+            appearance="Lean and quick on their feet",
+            clothing_style="traveler's gear",
+            characteristic_items=["map", "lute"],
+            distinctive_features=["tattooed arms"],
+        ),
+        psychological=PsychologicalAttributesModel(
+            personality_summary="Curious and brave",
+            personality_tags=["curious", "brave"],
+            motivations=["explore"],
+            values=["freedom"],
+            fears_and_weaknesses=[],
+            communication_style="friendly",
+            backstory="Left home seeking adventure",
+            quirks=["talks to animals"],
+        ),
+        present_in_scenario="scene_001",
+    )
+
+    print(
+        create_player.invoke(
+            {
+                **player_args.model_dump(),
+                "simulated_characters_state": characters_state,
+            }
+        )
+    )
+
+    print_step("Move Player")
+    print(
+        place_character.invoke(
+            {
+                "simulated_characters_state": characters_state,
+                "character_id": "char_003",
+                "new_scene_id": "scene_002",
+            }
+        )
+    )
+
+    print_step("Place Lia in Scene")
+    print(
+        place_character.invoke(
+            {
+                "simulated_characters_state": characters_state,
+                "character_id": "char_001",
+                "new_scene_id": "scene_002",
+            }
+        )
+    )
+
+    print_step("Unplace Bran")
+    print(
+        remove_character_from_scenario.invoke(
+            {
+                "simulated_characters_state": characters_state,
+                "character_id": "char_002",
+            }
         )
     )
 
     print_step("Final State")
-    print(list_characters(simulated_characters_state=characters_state))
+    print(
+        list_characters.invoke(
+            {
+                "simulated_characters_state": characters_state,
+                "list_identity": True,
+                "list_physical": True,
+                "list_psychological": False,
+            }
+        )
+    )
+
+    print_step("Filter By Gender")
+    print(
+        list_characters.invoke(
+            {
+                "simulated_characters_state": characters_state,
+                "attribute_to_filter": "gender",
+                "value_to_match": "female",
+            }
+        )
+    )
+
+    print_step("Player Details")
+    print(
+        get_player_details.invoke(
+            {
+                "simulated_characters_state": characters_state,
+            }
+        )
+    )
+
+    print_step("Modify Player Identity")
+    print(
+        modify_identity.invoke(
+            {
+                "simulated_characters_state": characters_state,
+                "character_id": "char_003",
+                "new_full_name": "Arin the Hero",
+            }
+        )
+    )
+
+    print_step("Attempt Modify Player Dynamic (should fail)")
+    print(
+        modify_dynamic_state.invoke(
+            {
+                "simulated_characters_state": characters_state,
+                "character_id": "char_003",
+                "new_current_emotion": "excited",
+            }
+        )
+    )
+
+    print_step("Attempt Modify Player Narrative (should fail)")
+    print(
+        modify_narrative.invoke(
+            {
+                "simulated_characters_state": characters_state,
+                "character_id": "char_003",
+                "new_narrative_role": "protagonist",
+            }
+        )
+    )
+
+    print_step("Attempt Delete Player (should fail)")
+    print(
+        delete_character.invoke(
+            {
+                "simulated_characters_state": characters_state,
+                "character_id": "char_003",
+            }
+        )
+    )
 
     for cid, char in characters_state.simulated_characters.items():
         print(f"\nID: {cid}")


### PR DESCRIPTION
## Summary
- document allowed player modifications in schema docs
- reject player updates from narrative and dynamic tools
- test modifying the player with identity and ensure dynamic/narrative fail

## Testing
- `pytest -q`
- `python backend/tests/character_execution_tools_manual_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68503e664f68832e84516688e3e1242b