### PR TITLE
Centralize character schema literals

### DIFF
--- a/backend/core_game/character/__init__.py
+++ b/backend/core_game/character/__init__.py
@@ -1,0 +1,13 @@
+from .constants import (
+    Gender,
+    CharacterType,
+    NarrativeRole,
+    NarrativeImportance,
+)
+
+__all__ = [
+    "Gender",
+    "CharacterType",
+    "NarrativeRole",
+    "NarrativeImportance",
+]

--- a/backend/core_game/character/constants.py
+++ b/backend/core_game/character/constants.py
@@ -1,0 +1,14 @@
+from typing import Literal
+
+# Centralized type aliases for commonly used Literal values
+Gender = Literal["male", "female", "non-binary", "undefined", "other"]
+CharacterType = Literal["player", "npc"]
+NarrativeRole = Literal[
+    "protagonist",
+    "secondary",
+    "extra",
+    "antagonist",
+    "ally",
+    "informational figure",
+]
+NarrativeImportance = Literal["important", "secondary", "minor", "inactive"]

--- a/backend/core_game/character/schemas.py
+++ b/backend/core_game/character/schemas.py
@@ -1,5 +1,11 @@
 from pydantic import BaseModel, Field
-from typing import Dict, List, Optional, Literal
+from typing import Dict, List, Optional
+from core_game.character.constants import (
+    Gender,
+    CharacterType,
+    NarrativeRole,
+    NarrativeImportance,
+)
 from core_game.character.field_descriptions import *
 
 # Internal counter used for sequential character ids
@@ -17,7 +23,7 @@ class IdentityModel(BaseModel):
     full_name: str = Field(..., description=IDENTITY_MODEL_FIELDS["full_name"])
     alias: Optional[str] = Field(default=None, description=IDENTITY_MODEL_FIELDS["alias"])
     age: int = Field(..., description=IDENTITY_MODEL_FIELDS["age"])
-    gender: Literal["male", "female", "non-binary", "undefined", "other"] = Field(..., description=IDENTITY_MODEL_FIELDS["gender"])
+    gender: Gender = Field(..., description=IDENTITY_MODEL_FIELDS["gender"])
     profession: str = Field(..., description=IDENTITY_MODEL_FIELDS["profession"])
     species: str = Field(..., description=IDENTITY_MODEL_FIELDS["species"])
     alignment: str = Field(..., description=IDENTITY_MODEL_FIELDS["alignment"])
@@ -50,9 +56,15 @@ class NarrativePurposeModel(BaseModel):
 
 class NarrativeWeightModel(BaseModel):
     """Defines a character's weight and function within the narrative."""
-    narrative_role: Literal["protagonist", "secondary", "extra", "antagonist", "ally", "informational figure"] = Field(..., description=NARRATIVE_WEIGHT_MODEL_FIELDS["narrative_role"])
-    current_narrative_importance: Literal["important", "secondary", "minor", "inactive"] = Field(..., description=NARRATIVE_WEIGHT_MODEL_FIELDS["narrative_importance"])
-    narrative_purposes: List[NarrativePurposeModel] = Field(..., description=NARRATIVE_WEIGHT_MODEL_FIELDS["narrative_purpose"])
+    narrative_role: NarrativeRole = Field(
+        ..., description=NARRATIVE_WEIGHT_MODEL_FIELDS["narrative_role"]
+    )
+    current_narrative_importance: NarrativeImportance = Field(
+        ..., description=NARRATIVE_WEIGHT_MODEL_FIELDS["narrative_importance"]
+    )
+    narrative_purposes: List[NarrativePurposeModel] = Field(
+        ..., description=NARRATIVE_WEIGHT_MODEL_FIELDS["narrative_purpose"]
+    )
 
 class KnowledgeModel(BaseModel):
     """Tracks the information known by the character."""
@@ -70,7 +82,7 @@ class DynamicStateModel(BaseModel):
 class CharacterBaseModel(BaseModel):
     """The base model that all character types inherit from."""
     id: str = Field(..., description="Unique identifier for the character.")
-    type: Literal["player", "npc"] = Field(default="player", description="Type of character.")
+    type: CharacterType = Field(default="player", description="Type of character.")
     identity: IdentityModel
     physical: PhysicalAttributesModel
     psychological: PsychologicalAttributesModel
@@ -80,12 +92,12 @@ class CharacterBaseModel(BaseModel):
 
 class PlayerCharacterModel(CharacterBaseModel):
     """A character controlled by a human player."""
-    type: Literal["player"] = Field(default="player", description="Type of character.")
+    type: CharacterType = Field(default="player", description="Type of character.")
 
 
 class NonPlayerCharacterModel(CharacterBaseModel):
     """A character controlled by the system (AI)."""
-    type: Literal["npc"] = Field(default="npc", description="Type of character.")
+    type: CharacterType = Field(default="npc", description="Type of character.")
     dynamic_state: DynamicStateModel
     narrative: NarrativeWeightModel
 

--- a/backend/subsystems/agents/character_cast/schemas/simulated_characters.py
+++ b/backend/subsystems/agents/character_cast/schemas/simulated_characters.py
@@ -2,6 +2,7 @@
 
 from typing import Dict, List, Any, Optional, Annotated, Literal
 from pydantic import BaseModel, Field as PydanticField, model_validator
+from core_game.character.constants import Gender, NarrativeRole, NarrativeImportance
 
 
 from core_game.character.schemas import (
@@ -50,7 +51,7 @@ class ModifyIdentityArgs(BaseModel):
     new_full_name: Optional[str] = PydanticField(None, description="New full name")
     new_alias: Optional[str] = PydanticField(None, description="New alias")
     new_age: Optional[int] = PydanticField(None, description="New age")
-    new_gender: Optional[Literal["male", "female", "non-binary", "undefined", "other"]] = PydanticField(
+    new_gender: Optional[Gender] = PydanticField(
         None, description="New gender"
     )
     new_profession: Optional[str] = PydanticField(None, description="New profession")
@@ -159,10 +160,10 @@ class ModifyNarrativeArgs(BaseModel):
         ...,
         description="ID of the NPC to modify; the player cannot be modified",
     )
-    new_narrative_role: Optional[Literal["protagonist", "secondary", "extra", "antagonist", "ally", "informational figure"]] = PydanticField(
+    new_narrative_role: Optional[NarrativeRole] = PydanticField(
         None, description="New narrative role"
     )
-    new_current_narrative_importance: Optional[Literal["important", "secondary", "minor", "inactive"]] = PydanticField(
+    new_current_narrative_importance: Optional[NarrativeImportance] = PydanticField(
         None, description="New narrative importance"
     )
     new_narrative_purposes: Optional[List[NarrativePurposeModel]] = PydanticField(

--- a/backend/subsystems/agents/character_cast/tools/character_tools.py
+++ b/backend/subsystems/agents/character_cast/tools/character_tools.py
@@ -1,6 +1,7 @@
 """Tool functions used by the character agent."""
 
 from typing import Annotated, Optional, Literal
+from core_game.character.constants import Gender
 from pydantic import BaseModel
 from langchain_core.tools import tool
 from langgraph.prebuilt import InjectedState
@@ -120,6 +121,10 @@ def create_npc(
     )
 
 
+# Backwards compatibility alias
+create_full_npc = create_npc
+
+
 @tool
 def finalize_simulation(
     justification: str,
@@ -210,7 +215,7 @@ def modify_identity(
     new_full_name: Optional[str] = None,
     new_alias: Optional[str] = None,
     new_age: Optional[int] = None,
-    new_gender: Optional[Literal["male", "female", "non-binary", "undefined", "other"]] = None,
+    new_gender: Optional[Gender] = None,
     new_profession: Optional[str] = None,
     new_species: Optional[str] = None,
     new_alignment: Optional[str] = None,


### PR DESCRIPTION
## Summary
- centralize gender, character type and narrative enums
- use these enums in character schemas
- update agent code to use new enums
- add `create_full_npc` alias for backwards compatibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68508d8b7548832e9f2f7b038cc5bee5