### PR TITLE
Move create_player logic to tool and add knowledge test

### DIFF
--- a/backend/subsystems/agents/character_cast/schemas/simulated_characters.py
+++ b/backend/subsystems/agents/character_cast/schemas/simulated_characters.py
@@ -398,35 +398,6 @@ class SimulatedCharactersModel(BaseModel):
             "\n".join(matches),
         )
 
-    def create_player(self, args_model: CreatePlayerArgs) -> str:
-        """(MODIFICATION tool) Create the player character."""
-        if self.player_character is not None:
-            return self._log_and_summarize(
-                "create_player",
-                args_model,
-                False,
-                "Error: Player already exists.",
-            )
-
-        new_id = self.generate_sequential_character_id(list(self.simulated_characters.keys()))
-        player = PlayerCharacterModel(
-            id=new_id,
-            identity=args_model.identity,
-            physical=args_model.physical,
-            psychological=args_model.psychological,
-            knowledge=args_model.knowledge,
-            present_in_scenario=args_model.present_in_scenario,
-        )
-
-        self.player_character = player
-        self.simulated_characters[new_id] = player
-
-        return self._log_and_summarize(
-            "create_player",
-            args_model,
-            True,
-            f"Player '{player.identity.full_name}' created with id {new_id} in scene {args_model.present_in_scenario}.",
-        )
 
     def get_player_details(self, args_model: GetPlayerDetailsArgs) -> str:
         """(QUERY tool) Get details about the player character."""

--- a/backend/subsystems/agents/character_cast/tools/character_tools.py
+++ b/backend/subsystems/agents/character_cast/tools/character_tools.py
@@ -158,7 +158,36 @@ def create_player(
         knowledge=knowledge,
         present_in_scenario=present_in_scenario,
     )
-    return simulated_characters_state.create_player(args_model=args_model)
+
+    if simulated_characters_state.player_character is not None:
+        return simulated_characters_state._log_and_summarize(
+            "create_player",
+            args_model,
+            False,
+            "Error: Player already exists.",
+        )
+
+    new_id = SimulatedCharactersModel.generate_sequential_character_id(
+        list(simulated_characters_state.simulated_characters.keys())
+    )
+    player = PlayerCharacterModel(
+        id=new_id,
+        identity=identity,
+        physical=physical,
+        psychological=psychological,
+        knowledge=knowledge,
+        present_in_scenario=present_in_scenario,
+    )
+
+    simulated_characters_state.player_character = player
+    simulated_characters_state.simulated_characters[new_id] = player
+
+    return simulated_characters_state._log_and_summarize(
+        "create_player",
+        args_model,
+        True,
+        f"Player '{player.identity.full_name}' created with id {new_id} in scene {present_in_scenario}.",
+    )
 
 
 @tool(args_schema=ToolGetPlayerDetailsArgs)

--- a/backend/tests/character_agent_knowledge_manual_test.py
+++ b/backend/tests/character_agent_knowledge_manual_test.py
@@ -1,0 +1,52 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from subsystems.agents.character_cast import get_character_graph_app
+from subsystems.agents.character_cast.schemas.graph_state import CharacterGraphState
+
+
+def print_step(title: str) -> None:
+    print(f"\n=== {title.upper()} ===")
+
+
+if __name__ == "__main__":
+    state = CharacterGraphState(
+        global_narrative_context=(
+            "a world where theres humanlike creatures (called Stoners) that are born with a stone incrustrated in their back. the stone keeps growing until they are crushed by its weight. some people that live freely and happy, their stone doesn't grow as fast. theres people that works mining other peoples stone with a pickaxe. when people dye, as the get crushed by its stone the only thing that remains in the surface is their stone, posing as a tombstone."
+        ),
+        character_rules_and_constraints=[
+            "Characters should have unique personalities and physical atributes that make them outstand.",
+        ],
+        current_objective="Create two unique NPCs who could appear in this context.",
+        other_guidelines="Keep them distinct from canonical characters.",
+        max_executor_iterations=3,
+    )
+
+    app = get_character_graph_app()
+
+    print_step("Run Graph - Create Characters")
+    final_data = app.invoke(state, {"recursion_limit": 40})
+    state = CharacterGraphState(**final_data)
+
+    print_step("Characters After Creation")
+    for cid, char in state.working_simulated_characters.simulated_characters.items():
+        print(f"ID: {cid}")
+        print(char.model_dump_json(indent=2))
+
+    # Prepare second run to add new knowledge
+    state.current_objective = (
+        "Add the acquired knowledge to all characters that the sun god has descended from the sky."
+    )
+    state.max_executor_iterations = 2
+
+    print_step("Run Graph - Add Knowledge")
+    final_data = app.invoke(state, {"recursion_limit": 40})
+    final_state = CharacterGraphState(**final_data)
+
+    print_step("Characters After Knowledge Update")
+    for cid, char in final_state.working_simulated_characters.simulated_characters.items():
+        print(f"ID: {cid}")
+        print(char.model_dump_json(indent=2))
+


### PR DESCRIPTION
## Summary
- move `create_player` logic from state model to tool for consistency with NPC creation
- add new manual test `character_agent_knowledge_manual_test.py` demonstrating running the graph twice and updating knowledge

## Testing
- `python -m py_compile backend/subsystems/agents/character_cast/tools/character_tools.py backend/subsystems/agents/character_cast/schemas/simulated_characters.py backend/tests/character_agent_knowledge_manual_test.py`

------
https://chatgpt.com/codex/tasks/task_e_685092b97cdc832e830ad0ed826bc3e8