### PR TITLE
Improve format for character and scenario queries

### DIFF
--- a/backend/subsystems/agents/character_cast/tools/character_tools.py
+++ b/backend/subsystems/agents/character_cast/tools/character_tools.py
@@ -33,6 +33,7 @@ from ..schemas.simulated_characters import (
     GetCharacterDetailsArgs,
     CreatePlayerArgs,
     GetPlayerDetailsArgs,
+    ListCharactersByScenarioArgs,
 )
 
 
@@ -77,6 +78,9 @@ class ToolCreatePlayerArgs(CreatePlayerArgs):
     simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
 
 class ToolGetPlayerDetailsArgs(GetPlayerDetailsArgs):
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+
+class ToolListCharactersByScenarioArgs(BaseModel):
     simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
 
 
@@ -224,6 +228,15 @@ def list_characters(
         list_narrative=list_narrative,
     )
     return simulated_characters_state.list_characters(args_model=args_model)
+
+
+@tool(args_schema=ToolListCharactersByScenarioArgs)
+def list_characters_by_scenario(
+    simulated_characters_state: Annotated[SimulatedCharactersModel, InjectedState("working_simulated_characters")]
+) -> str:
+    """(QUERY tool) List characters grouped by scenario."""
+    args_model = ListCharactersByScenarioArgs()
+    return simulated_characters_state.list_characters_by_scenario(args_model=args_model)
 
 
 @tool(args_schema=ToolGetCharacterDetailsArgs)
@@ -731,6 +744,7 @@ EXECUTORTOOLS = [
     create_npc,
     create_player,
     list_characters,
+    list_characters_by_scenario,
     get_player_details,
     get_character_details,
     modify_identity,

--- a/backend/subsystems/agents/map/nodes.py
+++ b/backend/subsystems/agents/map/nodes.py
@@ -65,7 +65,7 @@ def receive_result_for_validation_node(state: MapGraphState):
         for operation in operation_logs:
             if operation["success"]:
                 if operation["tool_called"] not in query_tool_names:
-                    final_str += f"Result of '{operation["tool_called"]}': {operation["message"]}.\n"
+                    final_str += f"Result of '{operation['tool_called']}': {operation['message']}.\n"
         return final_str
 
     state.working_simulated_map.executor_or_validator = "validator"

--- a/backend/subsystems/agents/map/schemas/simulated_map.py
+++ b/backend/subsystems/agents/map/schemas/simulated_map.py
@@ -173,31 +173,39 @@ class SimulatedMapModel(BaseModel):
         if not self.island_clusters:
             return "The simulated map currently has 0 scenarios."
         
-        summary = f"The simulated map has {len(self.simulated_scenarios)} scenarios and {len(self.island_clusters)} cluster(s) of scenarios:\n"
+        summary_lines = [
+            f"The simulated map has {len(self.simulated_scenarios)} scenarios and {len(self.island_clusters)} cluster(s) of scenarios:"
+        ]
         for i, cluster_set in enumerate(self.island_clusters, 1):
-            cluster_list_sorted = sorted(list(cluster_set)) 
-            
-            scenario_strings = []
-            num_to_display = len(cluster_list_sorted) if list_all_scenarios else (max_listed_per_cluster or len(cluster_list_sorted))
+            cluster_list_sorted = sorted(list(cluster_set))
+            num_to_display = len(cluster_list_sorted) if list_all_scenarios else (
+                max_listed_per_cluster or len(cluster_list_sorted)
+            )
 
+            scenario_lines: List[str] = []
             for k, scenario_id in enumerate(cluster_list_sorted):
                 if k < num_to_display:
                     scenario = self.simulated_scenarios.get(scenario_id)
                     if scenario:
-                        scenario_strings.append(f'"{scenario.name}" (ID: {scenario.id})')
+                        scenario_lines.append(f"  - \"{scenario.name}\" (ID: {scenario.id})")
                 else:
                     break
-            
-            summary_line = f"- Cluster {i} (contains {len(cluster_list_sorted)} scenarios): "
-            if scenario_strings:
-                summary_line += ", ".join(scenario_strings)
-                if not list_all_scenarios and len(cluster_list_sorted) > num_to_display:
-                    summary_line += f", ...and {len(cluster_list_sorted) - num_to_display} more."
-            else:
-                summary_line += "(No scenarios found for this cluster - this might indicate an issue)."
 
-            summary += summary_line + "\n"
-        return summary.strip()
+            if not list_all_scenarios and len(cluster_list_sorted) > num_to_display:
+                scenario_lines.append(
+                    f"  - ...and {len(cluster_list_sorted) - num_to_display} more."
+                )
+
+            if scenario_lines:
+                summary_lines.append(
+                    f"- Cluster {i} (contains {len(cluster_list_sorted)} scenarios):\n" + "\n".join(scenario_lines)
+                )
+            else:
+                summary_lines.append(
+                    f"- Cluster {i} (contains {len(cluster_list_sorted)} scenarios): (No scenarios found for this cluster - this might indicate an issue)."
+                )
+
+        return "\n".join(summary_lines)
 
     def _log_and_summarize(self, tool_name: str, args: BaseModel, success: bool, message: str) -> str:
         """Helper to log the operation and create consistent observation messages."""


### PR DESCRIPTION
## Summary
- add helper for human-readable nested dict formatting
- show nested character details using bullet lists
- list characters by scenario in sorted order with spacing
- pretty-print scenario cluster summaries

## Testing
- `python -m py_compile backend/subsystems/agents/character_cast/schemas/simulated_characters.py backend/subsystems/agents/character_cast/tools/character_tools.py backend/subsystems/agents/map/nodes.py backend/subsystems/agents/map/schemas/simulated_map.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850a2584390832eb25ae34bd82c07c4