### PR TITLE
Remove set relationship tool

### DIFF
--- a/backend/subsystems/agents/relationship/tools/relationship_tools.py
+++ b/backend/subsystems/agents/relationship/tools/relationship_tools.py
@@ -3,16 +3,16 @@
 from typing import Annotated, Optional
 from langchain_core.tools import tool
 from langgraph.prebuilt import InjectedState
+from core_game.character.schemas import RelationshipType
 from ..schemas.simulated_relationships import (
     SimulatedRelationshipsModel,
-    SetRelationshipArgs,
     GetRelationshipDetailsArgs,
     FinalizeSimulationArgs,
+    CreateRelationshipTypeArgs,
+    CreateUndirectedRelationshipArgs,
+    CreateDirectedRelationshipArgs,
+    ModifyRelationshipIntensityArgs,
 )
-
-
-class ToolSetRelationshipArgs(SetRelationshipArgs):
-    simulated_relationships_state: Annotated[SimulatedRelationshipsModel, InjectedState("working_simulated_relationships")]
 
 
 class ToolGetRelationshipDetailsArgs(GetRelationshipDetailsArgs):
@@ -23,22 +23,20 @@ class ToolFinalizeSimulationArgs(FinalizeSimulationArgs):
     simulated_relationships_state: Annotated[SimulatedRelationshipsModel, InjectedState("working_simulated_relationships")]
 
 
-@tool(args_schema=ToolSetRelationshipArgs)
-def set_relationship(
-    source_character_id: str,
-    target_character_id: str,
-    relationship_type: str,
-    simulated_relationships_state: Annotated[SimulatedRelationshipsModel, InjectedState("working_simulated_relationships")],
-    intensity: Optional[int] = None,
-) -> str:
-    """(MODIFICATION tool) Set or update a relationship between two characters."""
-    args_model = SetRelationshipArgs(
-        source_character_id=source_character_id,
-        target_character_id=target_character_id,
-        relationship_type=relationship_type,
-        intensity=intensity,
-    )
-    return simulated_relationships_state.set_relationship(args_model)
+class ToolCreateRelationshipTypeArgs(CreateRelationshipTypeArgs):
+    simulated_relationships_state: Annotated[SimulatedRelationshipsModel, InjectedState("working_simulated_relationships")]
+
+
+class ToolCreateUndirectedRelationshipArgs(CreateUndirectedRelationshipArgs):
+    simulated_relationships_state: Annotated[SimulatedRelationshipsModel, InjectedState("working_simulated_relationships")]
+
+
+class ToolCreateDirectedRelationshipArgs(CreateDirectedRelationshipArgs):
+    simulated_relationships_state: Annotated[SimulatedRelationshipsModel, InjectedState("working_simulated_relationships")]
+
+
+class ToolModifyRelationshipIntensityArgs(ModifyRelationshipIntensityArgs):
+    simulated_relationships_state: Annotated[SimulatedRelationshipsModel, InjectedState("working_simulated_relationships")]
 
 
 @tool(args_schema=ToolGetRelationshipDetailsArgs)
@@ -65,8 +63,173 @@ def finalize_simulation(
     return simulated_relationships_state.finalize_simulation(args_model)
 
 
+@tool(args_schema=ToolCreateRelationshipTypeArgs)
+def create_relationship_type(
+    name: str,
+    simulated_relationships_state: Annotated[SimulatedRelationshipsModel, InjectedState("working_simulated_relationships")],
+    explanation: Optional[str] = None,
+) -> str:
+    """(MODIFICATION tool) Create a new relationship type."""
+    args_model = CreateRelationshipTypeArgs(name=name, explanation=explanation)
+    if name in simulated_relationships_state.relationship_types:
+        return simulated_relationships_state._log_and_summarize(
+            "create_relationship_type",
+            args_model,
+            False,
+            f"Relationship type '{name}' already exists.",
+        )
+    simulated_relationships_state.relationship_types[name] = RelationshipType(
+        name=name, explanation=explanation
+    )
+    return simulated_relationships_state._log_and_summarize(
+        "create_relationship_type",
+        args_model,
+        True,
+        f"Relationship type '{name}' created.",
+    )
+
+
+@tool(args_schema=ToolCreateUndirectedRelationshipArgs)
+def create_undirected_relationship(
+    character_a_id: str,
+    character_b_id: str,
+    relationship_type: str,
+    simulated_relationships_state: Annotated[SimulatedRelationshipsModel, InjectedState("working_simulated_relationships")],
+    intensity: Optional[int] = None,
+) -> str:
+    """(MODIFICATION tool) Create a bidirectional relationship between two characters."""
+    args_model = CreateUndirectedRelationshipArgs(
+        character_a_id=character_a_id,
+        character_b_id=character_b_id,
+        relationship_type=relationship_type,
+        intensity=intensity,
+    )
+    result_a = create_directed_relationship.func(
+        source_character_id=character_a_id,
+        target_character_id=character_b_id,
+        relationship_type=relationship_type,
+        simulated_relationships_state=simulated_relationships_state,
+        intensity=intensity,
+    )
+    result_b = create_directed_relationship.func(
+        source_character_id=character_b_id,
+        target_character_id=character_a_id,
+        relationship_type=relationship_type,
+        simulated_relationships_state=simulated_relationships_state,
+        intensity=intensity,
+    )
+    success = "already exists" not in result_a and "already exists" not in result_b
+    message = (
+        f"Undirected relationship '{relationship_type}' created between {character_a_id} and {character_b_id}."
+        if success
+        else "One or both directions already existed."
+    )
+    return simulated_relationships_state._log_and_summarize(
+        "create_undirected_relationship",
+        args_model,
+        success,
+        message,
+    )
+
+
+@tool(args_schema=ToolCreateDirectedRelationshipArgs)
+def create_directed_relationship(
+    source_character_id: str,
+    target_character_id: str,
+    relationship_type: str,
+    simulated_relationships_state: Annotated[SimulatedRelationshipsModel, InjectedState("working_simulated_relationships")],
+    intensity: Optional[int] = None,
+) -> str:
+    """(MODIFICATION tool) Create a one-way relationship if it doesn't exist."""
+    args_model = CreateDirectedRelationshipArgs(
+        source_character_id=source_character_id,
+        target_character_id=target_character_id,
+        relationship_type=relationship_type,
+        intensity=intensity,
+    )
+    existing = (
+        simulated_relationships_state.relationships_matrix
+        .get(source_character_id, {})
+        .get(target_character_id, {})
+        .get(relationship_type)
+    )
+    if existing is not None:
+        return simulated_relationships_state._log_and_summarize(
+            "create_directed_relationship",
+            args_model,
+            False,
+            "Relationship already exists.",
+        )
+
+    r_type = simulated_relationships_state.relationship_types.get(relationship_type)
+    if r_type is None:
+        return simulated_relationships_state._log_and_summarize(
+            "create_directed_relationship",
+            args_model,
+            False,
+            f"Relationship type '{relationship_type}' not found.",
+        )
+    rel = CharacterRelationship(type=r_type, intensity=intensity)
+    simulated_relationships_state.relationships_matrix.setdefault(source_character_id, {}).setdefault(
+        target_character_id, {}
+    )[relationship_type] = rel
+    return simulated_relationships_state._log_and_summarize(
+        "create_directed_relationship",
+        args_model,
+        True,
+        f"Directed relationship '{relationship_type}' set from {source_character_id} to {target_character_id}.",
+    )
+
+
+@tool(args_schema=ToolModifyRelationshipIntensityArgs)
+def modify_relationship_intensity(
+    source_character_id: str,
+    target_character_id: str,
+    relationship_type: str,
+    new_intensity: int,
+    simulated_relationships_state: Annotated[SimulatedRelationshipsModel, InjectedState("working_simulated_relationships")],
+) -> str:
+    """(MODIFICATION tool) Change the intensity of an existing relationship."""
+    args_model = ModifyRelationshipIntensityArgs(
+        source_character_id=source_character_id,
+        target_character_id=target_character_id,
+        relationship_type=relationship_type,
+        new_intensity=new_intensity,
+    )
+    rel = (
+        simulated_relationships_state.relationships_matrix
+        .get(source_character_id, {})
+        .get(target_character_id, {})
+        .get(relationship_type)
+    )
+    if rel is None:
+        return simulated_relationships_state._log_and_summarize(
+            "modify_relationship_intensity",
+            args_model,
+            False,
+            "Relationship not found.",
+        )
+    if rel.intensity is None:
+        return simulated_relationships_state._log_and_summarize(
+            "modify_relationship_intensity",
+            args_model,
+            False,
+            "Relationship has no intensity to modify.",
+        )
+    rel.intensity = new_intensity
+    return simulated_relationships_state._log_and_summarize(
+        "modify_relationship_intensity",
+        args_model,
+        True,
+        f"Intensity updated to {new_intensity}.",
+    )
+
+
 EXECUTORTOOLS = [
-    set_relationship,
+    create_relationship_type,
+    create_undirected_relationship,
+    create_directed_relationship,
+    modify_relationship_intensity,
     get_relationship_details,
     finalize_simulation,
 ]

--- a/backend/tests/relationship_tools_manual_test.py
+++ b/backend/tests/relationship_tools_manual_test.py
@@ -5,14 +5,16 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from subsystems.agents.relationship.schemas.simulated_relationships import (
     SimulatedRelationshipsModel,
-    SetRelationshipArgs,
     GetRelationshipDetailsArgs,
     FinalizeSimulationArgs,
 )
 from subsystems.agents.relationship.tools.relationship_tools import (
-    set_relationship,
     get_relationship_details,
     finalize_simulation,
+    create_relationship_type,
+    create_undirected_relationship,
+    create_directed_relationship,
+    modify_relationship_intensity,
 )
 from core_game.character.schemas import RelationshipType
 
@@ -28,12 +30,46 @@ if __name__ == "__main__":
     }
     sim_rels = SimulatedRelationshipsModel(relationship_types=rel_types)
 
-    print_step("Set Relationship")
-    print(set_relationship(
+    print_step("Create Relationship Type")
+    print(create_relationship_type(
+        name="mentor",
+        explanation="Mentorship bond",
+        simulated_relationships_state=sim_rels,
+    ))
+
+    print_step("Create Directed Relationship")
+    print(create_directed_relationship(
         source_character_id="char_1",
         target_character_id="char_2",
         relationship_type="friend",
         intensity=7,
+        simulated_relationships_state=sim_rels,
+    ))
+
+    print_step("Create Undirected Relationship")
+    print(create_undirected_relationship(
+        character_a_id="char_1",
+        character_b_id="char_3",
+        relationship_type="mentor",
+        intensity=5,
+        simulated_relationships_state=sim_rels,
+    ))
+
+    print_step("Create Directed Relationship")
+    print(create_directed_relationship(
+        source_character_id="char_2",
+        target_character_id="char_1",
+        relationship_type="enemy",
+        intensity=6,
+        simulated_relationships_state=sim_rels,
+    ))
+
+    print_step("Modify Intensity")
+    print(modify_relationship_intensity(
+        source_character_id="char_1",
+        target_character_id="char_2",
+        relationship_type="friend",
+        new_intensity=9,
         simulated_relationships_state=sim_rels,
     ))
 


### PR DESCRIPTION
## Summary
- drop SetRelationshipArgs and set_relationship helper
- implement directed relationship creation directly in the tool
- adjust executor tool list and manual test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685150b5f1ec832ea73ada2decde5522