### PR TITLE
Refactor: move character containers to dedicated domain

### DIFF
--- a/backend/core_game/character/__init__.py
+++ b/backend/core_game/character/__init__.py
@@ -4,10 +4,13 @@ from .constants import (
     NarrativeRole,
     NarrativeImportance,
 )
+from .domain import Characters, Relationships
 
 __all__ = [
     "Gender",
     "CharacterType",
     "NarrativeRole",
     "NarrativeImportance",
+    "Characters",
+    "Relationships",
 ]

--- a/backend/core_game/character/domain.py
+++ b/backend/core_game/character/domain.py
@@ -1,0 +1,47 @@
+from typing import Dict
+
+from .schemas import (
+    CharacterBaseModel,
+    PlayerCharacterModel,
+    RelationshipType,
+    CharacterRelationship,
+)
+
+
+class Characters:
+    """Domain wrapper around the collection of all game characters."""
+
+    def __init__(
+        self,
+        registry: Dict[str, CharacterBaseModel],
+        player_character: PlayerCharacterModel,
+    ) -> None:
+        self.registry = registry
+        self.player = player_character
+
+    def add(self, character: CharacterBaseModel) -> None:
+        self.registry[character.id] = character
+
+    def get(self, character_id: str) -> CharacterBaseModel | None:
+        return self.registry.get(character_id)
+
+
+class Relationships:
+    """Domain wrapper around character relationships."""
+
+    def __init__(
+        self,
+        relationship_types: Dict[str, RelationshipType],
+        matrix: Dict[str, Dict[str, Dict[str, CharacterRelationship]]],
+    ) -> None:
+        self.relationship_types = relationship_types
+        self.matrix = matrix
+
+    def get(
+        self, source: str, target: str, relationship_type: str
+    ) -> CharacterRelationship | None:
+        return (
+            self.matrix.get(source, {})
+            .get(target, {})
+            .get(relationship_type)
+        )

--- a/backend/core_game/game/domain.py
+++ b/backend/core_game/game/domain.py
@@ -1,11 +1,85 @@
-from core_game.map.schemas import ScenarioModel
-from core_game.map.domain import GameMap, Scenario
-from core_game.character.schemas import CharacterBaseModel, PlayerCharacterModel
-from core_game.game.schemas import GameStateModel
-from typing import Dict
+from typing import Dict, List, Any, Optional
+import json
+from pathlib import Path
+
+from core_game.map.domain import GameMap
+from core_game.character.domain import Characters, Relationships
+from core_game.game.schemas import GameStateModel, GameSessionModel
+from core_game.time.domain import GameTime
+
+
+class GameSession:
+    """Domain wrapper around :class:`GameSessionModel`."""
+
+    def __init__(self, model: GameSessionModel) -> None:
+        self._data = model
+        self.session_id: str = model.session_id
+        self.player_prompt: str = model.player_prompt
+        self.time: GameTime = GameTime(model.narrative_time)
+        self.global_flags: Dict[str, Any] = model.global_flags
+
+
 
 
 class GameState:
-    def __init__(self, game_state_model: GameStateModel):
+    def __init__(self, game_state_model: Optional[GameStateModel] = None) -> None:
+        """Instantiate the domain game state from its data model."""
+
+        self._data: Optional[GameStateModel] = None
+        self.session: Optional[GameSession] = None
+        self.game_map: Optional[GameMap] = None
+        self.characters: Optional[Characters] = None
+        self.relationships: Optional[Relationships] = None
+        self.narrative_state = None
+        self.game_event_log: List = []
+
+        if game_state_model is not None:
+            self._populate_from_model(game_state_model)
+
+    # ------------------------------------------------------------------
+    # Initialization helpers
+    # ------------------------------------------------------------------
+    def _populate_from_model(self, game_state_model: GameStateModel) -> None:
+        """Populate the domain state from a :class:`GameStateModel`."""
+
+        self._data = game_state_model
+
+        # Session information
+        self.session: GameSession = GameSession(game_state_model.session)
+
+        # World map
         self.game_map: GameMap = GameMap(game_state_model.game_map)
+
+        # Characters
+        self.characters = Characters(
+            game_state_model.character_registry,
+            game_state_model.player_character,
+        )
+
+        # Relationships
+        self.relationships = Relationships(
+            game_state_model.relationship_types,
+            game_state_model.relationships_matrix,
+        )
+
+        # Narrative state
+        self.narrative_state = game_state_model.narrative_state
+
+        # Event log
+        self.game_event_log: List = game_state_model.game_event_log
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def load_from_file(self, file_path: str = "game_state.json") -> None:
+        """Load game state data from a JSON file."""
+
+        if not Path(file_path).is_file():
+            raise FileNotFoundError(file_path)
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        model = GameStateModel(**data)
+        self._populate_from_model(model)
 

--- a/backend/core_game/game/singleton.py
+++ b/backend/core_game/game/singleton.py
@@ -1,0 +1,11 @@
+from .domain import GameState
+
+class GameStateSingleton:
+    _instance: GameState | None = None
+
+    @classmethod
+    def get_instance(cls) -> GameState:
+        if cls._instance is None:
+            cls._instance = GameState()
+            cls._instance.load_from_file()
+        return cls._instance


### PR DESCRIPTION
## Summary
- introduce `Characters` and `Relationships` in `character.domain`
- expose the new classes from `character/__init__`
- update `GameState` to import these classes from the new module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851993fb704832ebb3fefbb17b3e2c3