### PR TITLE
Add generation orchestrator with seed and refinement loop

### DIFF
--- a/backend/subsystems/generation/nodes.py
+++ b/backend/subsystems/generation/nodes.py
@@ -1,0 +1,13 @@
+from subsystems.generation.schemas.graph_state import GenerationGraphState
+
+
+def start_generation(state: GenerationGraphState):
+    """Initial node for the generation workflow."""
+    print("---ENTERING: START GENERATION NODE---")
+    return {}
+
+
+def finalize_generation(state: GenerationGraphState):
+    """Final node for the generation workflow."""
+    print("---ENTERING: FINALIZE GENERATION NODE---")
+    return {}

--- a/backend/subsystems/generation/orchestrator.py
+++ b/backend/subsystems/generation/orchestrator.py
@@ -1,0 +1,27 @@
+from langgraph.graph import StateGraph, END, START
+
+from subsystems.generation.schemas.graph_state import GenerationGraphState
+from subsystems.generation.nodes import start_generation, finalize_generation
+from subsystems.generation.seed.orchestrator import get_seed_generator_graph_app
+from subsystems.generation.refinement_loop.orchestrator import get_refinement_loop_graph_app
+
+
+def get_generation_graph_app():
+    """Builds the overall generation graph."""
+    workflow = StateGraph(GenerationGraphState)
+    seed_sub_graph = get_seed_generator_graph_app()
+    refinement_sub_graph = get_refinement_loop_graph_app()
+
+    workflow.add_node("start_generation", start_generation)
+    workflow.add_node("seed_generation", seed_sub_graph)
+    workflow.add_node("refinement_loop", refinement_sub_graph)
+    workflow.add_node("finalize_generation", finalize_generation)
+
+    workflow.add_edge(START, "start_generation")
+    workflow.add_edge("start_generation", "seed_generation")
+    workflow.add_edge("seed_generation", "refinement_loop")
+    workflow.add_edge("refinement_loop", "finalize_generation")
+    workflow.add_edge("finalize_generation", END)
+
+    app = workflow.compile()
+    return app


### PR DESCRIPTION
## Summary
- implement basic nodes for the `generation` workflow
- create orchestrator chaining seed and refinement loop subgraphs

## Testing
- `pytest -q` *(fails: SyntaxError in simulated/characters.py)*

------
https://chatgpt.com/codex/tasks/task_e_685c395b36b0832ea5ef51bee7672b08