### PR TITLE
Update character handler to match map handler design

### DIFF
--- a/backend/simulated/components/characters.py
+++ b/backend/simulated/components/characters.py
@@ -290,4 +290,10 @@ class SimulatedCharacters:
         characters = self.filter_characters(None, None)
         if not characters:
             return "No characters created yet."
-        return f"Cast has {self.characters_count()} Characters{", and no player character yet" if not self._working_state.has_player() else ""}: " + ", ".join(f"{c.identity.full_name}({cid})" for cid, c in characters.items())
+        suffix = ", and no player character yet" if not self._working_state.has_player() else ""
+        return (
+            f"Cast has {self.characters_count()} characters{suffix}: "
+            + ", ".join(
+                f"{c.identity.full_name}({cid})" for cid, c in characters.items()
+            )
+        )

--- a/backend/subsystems/agents/character_handler/nodes.py
+++ b/backend/subsystems/agents/character_handler/nodes.py
@@ -4,22 +4,31 @@ load_dotenv()
 
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import ToolNode
+from typing import Sequence
 
 from .schemas.graph_state import CharacterGraphState
 from .prompts.reasoning import format_character_reason_prompt
-from .tools.character_tools import EXECUTORTOOLS
+from .prompts.validating import format_character_validation_prompt
+from .tools.character_tools import EXECUTORTOOLS, VALIDATIONTOOLS, validate_simulated_characters
 from utils.message_window import get_valid_messages_window
-from simulated.game_state import SimulatedGameStateSingleton
+from langchain_core.messages import BaseMessage, HumanMessage, RemoveMessage
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+from simulated.singleton import SimulatedGameStateSingleton
+from subsystems.agents.utils.logs import ToolLog
 
 def receive_objective_node(state: CharacterGraphState):
     print("---ENTERING: RECEIVE OBJECTIVE NODE---")
-
-    initial_summary = SimulatedGameStateSingleton.get_instance().simulated_characters.get_initial_summary()
+    SimulatedGameStateSingleton.begin_transaction()
+    initial_summary = (
+        SimulatedGameStateSingleton.get_instance()
+        .simulated_characters.get_initial_summary()
+    )
     return {
+        "characters_current_try": 0,
         "messages_field_to_update": "characters_executor_messages",
         "logs_field_to_update": "characters_executor_applied_operations_log",
         "characters_current_executor_iteration": 0,
-        "characters_initial_summary": initial_summary
+        "characters_initial_summary": initial_summary,
     }
 
 
@@ -27,12 +36,15 @@ def character_executor_reason_node(state: CharacterGraphState):
     print("---ENTERING: REASON EXECUTION NODE---")
     llm = ChatOpenAI(model="gpt-4.1-mini").bind_tools(EXECUTORTOOLS, tool_choice="any")
     full_prompt = format_character_reason_prompt(
-        initial_characters_summary=state.characters_initial_summary,
+        foundational_lore_document=state.characters_foundational_lore_document,
+        recent_operations_summary=state.characters_recent_operations_summary,
+        relevant_entity_details=state.characters_relevant_entity_details,
+        additional_information=state.characters_additional_information,
+        rules_and_constraints=state.characters_rules_and_constraints,
+        initial_summary=state.characters_initial_summary,
         objective=state.characters_current_objective,
         other_guidelines=state.characters_other_guidelines,
         messages=get_valid_messages_window(state.characters_executor_messages, 30),
-        narrative_context=state.characters_global_narrative_context,
-        character_rules_and_constraints=state.characters_rules_and_constraints,
     )
     state.characters_current_executor_iteration += 1
     response = llm.invoke(full_prompt)
@@ -44,4 +56,89 @@ def character_executor_reason_node(state: CharacterGraphState):
 
 character_executor_tool_node = ToolNode(EXECUTORTOOLS)
 character_executor_tool_node.messages_key = "characters_executor_messages"
+
+
+def receive_result_for_validation_node(state: CharacterGraphState):
+    print("---ENTERING: RECEIVE RESULT FOR VALIDATION NODE---")
+
+    def format_relevant_executing_agent_logs(operation_logs: Sequence[ToolLog]) -> str:
+        final_str = ""
+        for operation in operation_logs:
+            if operation.success:
+                if not operation.is_query:
+                    final_str += f"Result of '{operation.tool_called}': {operation.message}\n"
+        return final_str
+
+    return {
+        "characters_validation_messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES)],
+        "messages_field_to_update": "characters_validation_messages",
+        "characters_executor_agent_relevant_logs": format_relevant_executing_agent_logs(state.characters_executor_applied_operations_log),
+        "logs_field_to_update": "characters_validator_applied_operations_log",
+        "characters_agent_validated": False,
+        "characters_agent_validation_conclusion_flag": False,
+        "characters_agent_validation_assessment_reasoning": "",
+        "characters_agent_validation_suggested_improvements": "",
+        "characters_current_validation_iteration": 0,
+    }
+
+
+def character_validation_reason_node(state: CharacterGraphState):
+    print("---ENTERING: REASON VALIDATION NODE---")
+
+    state.characters_current_validation_iteration += 1
+    if state.characters_current_validation_iteration <= state.characters_max_validation_iterations:
+        validation_llm = ChatOpenAI(model="gpt-4.1-mini").bind_tools(VALIDATIONTOOLS, tool_choice="any")
+    else:
+        validation_llm = ChatOpenAI(model="gpt-4.1-mini").bind_tools([validate_simulated_characters], tool_choice="any")
+
+    full_prompt = format_character_validation_prompt(
+        state.characters_current_objective,
+        state.characters_executor_agent_relevant_logs,
+        state.characters_validation_messages,
+    )
+    response = validation_llm.invoke(full_prompt)
+    return {
+        "characters_validation_messages": [response],
+        "characters_current_validation_iteration": state.characters_current_validation_iteration,
+    }
+
+
+character_validation_tool_node = ToolNode(VALIDATIONTOOLS)
+character_validation_tool_node.messages_key = "characters_validation_messages"
+
+
+def retry_executor_node(state: CharacterGraphState):
+    print("---ENTERING: RETRY NODE---")
+
+    feedback = (
+        "Here's some human feedback on how you have done so far on your task:\n "
+        "You have still not completed your task\n Reason: "
+        f"{state.characters_agent_validation_assessment_reasoning}\n Suggestion/s:{state.characters_agent_validation_suggested_improvements} "
+    )
+
+    feedback_message = HumanMessage(feedback)
+
+    return {
+        "characters_executor_messages": [feedback_message],
+        "messages_field_to_update": "characters_executor_messages",
+        "logs_field_to_update": "characters_executor_applied_operations_log",
+        "characters_current_executor_iteration": 0,
+        "characters_current_try": state.characters_current_try + 1,
+    }
+
+
+def final_node_success(state: CharacterGraphState):
+    print("---ENTERING: LAST NODE OBJECTIVE SUCCESS---")
+    SimulatedGameStateSingleton.commit()
+    return {
+        "characters_task_succeeded_final": True,
+    }
+
+
+def final_node_failure(state: CharacterGraphState):
+    print("---ENTERING: LAST NODE OBJECTIVE FAILED---")
+    SimulatedGameStateSingleton.rollback()
+    return {
+        "characters_task_succeeded_final": False,
+    }
 

--- a/backend/subsystems/agents/character_handler/orchestrator.py
+++ b/backend/subsystems/agents/character_handler/orchestrator.py
@@ -8,33 +8,83 @@ from .nodes import (
     receive_objective_node,
     character_executor_reason_node,
     character_executor_tool_node,
+    receive_result_for_validation_node,
+    character_validation_reason_node,
+    character_validation_tool_node,
+    retry_executor_node,
+    final_node_success,
+    final_node_failure,
 )
 
 
-def iteration_limit_exceeded(state: CharacterGraphState) -> str:
-    if state.characters_current_executor_iteration >= state.characters_max_executor_iterations or state.characters_task_finalized_by_agent:
-        return "finalize"
-    return "continue"
+def iteration_limit_exceeded_or_agent_finalized(state: CharacterGraphState) -> str:
+    current_iteration = state.characters_current_executor_iteration
+    max_iterations = state.characters_max_executor_iterations
+    if state.characters_task_finalized_by_agent or current_iteration >= max_iterations:
+        if state.characters_max_validation_iterations > 0:
+            return "finalize_executor_and_validate"
+        else:
+            return "finalize_executor_and_succeed"
+    else:
+        return "continue_executor"
+
+
+def iteration_limit_exceeded_or_agent_validated(state: CharacterGraphState) -> str:
+    current_iteration = state.characters_current_validation_iteration
+    tries_to_evaluate_after_max_iterations = 3
+    max_iterations = state.characters_max_validation_iterations + tries_to_evaluate_after_max_iterations
+    if state.characters_agent_validated or current_iteration >= max_iterations:
+        if state.characters_agent_validation_conclusion_flag:
+            return "finalize_success"
+        else:
+            if state.characters_current_try <= state.characters_max_retries:
+                return "retry_executor"
+            else:
+                return "finalize_failure"
+    else:
+        return "continue_validation"
 
 
 def get_character_graph_app():
     workflow = StateGraph(CharacterGraphState)
 
-    workflow.add_node("receive_objective", receive_objective_node)
+    workflow.add_node("executor_receive_objective", receive_objective_node)
     workflow.add_node("executor_reason", character_executor_reason_node)
     workflow.add_node("executor_tool", character_executor_tool_node)
+    workflow.add_node("validation_receive_result", receive_result_for_validation_node)
+    workflow.add_node("validation_reason", character_validation_reason_node)
+    workflow.add_node("validation_tool", character_validation_tool_node)
+    workflow.add_node("retry_executor", retry_executor_node)
+    workflow.add_node("final_node_success", final_node_success)
+    workflow.add_node("final_node_failure", final_node_failure)
 
-    workflow.add_edge(START, "receive_objective")
-    workflow.add_edge("receive_objective", "executor_reason")
+    workflow.add_edge(START, "executor_receive_objective")
+    workflow.add_edge("executor_receive_objective", "executor_reason")
     workflow.add_edge("executor_reason", "executor_tool")
     workflow.add_conditional_edges(
         "executor_tool",
-        iteration_limit_exceeded,
+        iteration_limit_exceeded_or_agent_finalized,
         {
-            "continue": "executor_reason",
-            "finalize": END,
+            "continue_executor": "executor_reason",
+            "finalize_executor_and_validate": "validation_receive_result",
+            "finalize_executor_and_succeed": "final_node_success",
         },
     )
+    workflow.add_edge("validation_receive_result", "validation_reason")
+    workflow.add_edge("validation_reason", "validation_tool")
+    workflow.add_conditional_edges(
+        "validation_tool",
+        iteration_limit_exceeded_or_agent_validated,
+        {
+            "continue_validation": "validation_reason",
+            "finalize_success": "final_node_success",
+            "finalize_failure": "final_node_failure",
+            "retry_executor": "retry_executor",
+        },
+    )
+    workflow.add_edge("retry_executor", "executor_reason")
+    workflow.add_edge("final_node_success", END)
+    workflow.add_edge("final_node_failure", END)
 
     app = workflow.compile()
     return app

--- a/backend/subsystems/agents/character_handler/prompts/validating.py
+++ b/backend/subsystems/agents/character_handler/prompts/validating.py
@@ -1,0 +1,73 @@
+from typing import List, Sequence
+from langchain_core.prompts import ChatPromptTemplate
+from langchain.prompts import SystemMessagePromptTemplate, MessagesPlaceholder, HumanMessagePromptTemplate
+from langchain_core.messages import BaseMessage
+
+REACT_VALIDATOR_SYSTEM_PROMPT_TEMPLATE_STRING = """\
+## ROLE ##
+You are a VideoGame Character Validation Agent. Your specialty is to meticulously analyze the conformity of the simulated cast against a set of initial design objectives. You are logical, detail-oriented, and your reasoning is strictly based on the evidence provided.
+
+## Your Primary Objective ##
+Your primary mission is to **determine if the simulated characters MEET or DO NOT MEET the `characters_objective`**.
+
+## INPUT (Inputs You Will Receive) ##
+For each validation task, you will receive the following information:
+
+1.  **`characters_objective`**: A description of the rules, constraints and requirements the characters were supposed to fulfill.
+2.  **`constructor_agent_logs`**: A sequential record of actions and observations results from the agent that created or modified the characters. These logs will allow you to understand the constructor agent's decision-making process.
+
+## Available Tools ##
+You have access to a set of tools. Each comes with a detailed description and a schema for its expected arguments. Use these tools exactly as defined. **Do not invent new tools or use any that are not listed.** Pay close attention to the required arguments for each tool.
+
+## Your Work Process (ReAct Loop): ##
+1. **REASON:** Carefully analyze the objective, all provided context, the current state of the final simulated characters (based on previous tool observations). Decide on the *next most logical action/s* to move toward the objective.
+2. **ACT:** Choose the appropriate tool / tools and call them using the correct arguments as defined in its schema.
+    - If you need more information about the current state of the characters to make an informed decision, USE QUERY TOOLS.
+    - If you have sufficient information, select the validate tool to give a final validation.
+3. **OBSERVE:** You will receive a result from the tool. Use this information in your next reasoning step.
+    - If you called a query tool, the observation will contain the requested information.
+4. **REPEAT:** Continue this Reason-Act-Observe cycle until you are confident that you can give a validation.
+
+## Task Completion ##
+Once you are convinced and have enough information to know whether the characters MEET or DO NOT MEET the `characters_objective`:
+- You must call the `validate_simulated_characters` tool.
+- This tool requires a flag indicating if the characters meet the objective or not, the reasoning behind this evaluation and an argument to place the suggested improvements towards the objective in case the cast did not satisfy the objective.
+- This **MUST BE YOUR FINAL ACTION**. Do not call any other tools afterward.
+
+## Error Handling ##
+If a tool returns an error, analyze the error message in your OBSERVE step. In your next REASONING step, decide how to fix the issue: you may retry the tool with different arguments, try an alternative tool, or reconsider part of your strategy.
+
+Remember to think step by step. Your goal is to evaluate accurately the work of the agent that constructed the cast.
+"""
+
+REACT_VALIDATOR_HUMAN_PROMPT_TEMPLATE_STRING = """\
+**1. Characters Objective (`characters_objective`):**
+{characters_objective}
+**2. Constructor Agent Logs (`constructor_agent_logs`):**
+{constructor_agent_logs}
+"""
+
+REACT_VALIDATOR_SYSTEM_PROMPT_TEMPLATE = SystemMessagePromptTemplate.from_template(
+    REACT_VALIDATOR_SYSTEM_PROMPT_TEMPLATE_STRING,
+)
+
+REACT_VALIDATOR_HUMAN_PROMPT_TEMPLATE = HumanMessagePromptTemplate.from_template(
+    REACT_VALIDATOR_HUMAN_PROMPT_TEMPLATE_STRING
+)
+
+chat_prompt_template = ChatPromptTemplate([
+    REACT_VALIDATOR_SYSTEM_PROMPT_TEMPLATE,
+    REACT_VALIDATOR_HUMAN_PROMPT_TEMPLATE,
+    MessagesPlaceholder(variable_name="agent_scratchpad"),
+])
+
+def format_character_validation_prompt(characters_objective: str, constructor_agent_logs: str, validating_messages: Sequence[BaseMessage]) -> List[BaseMessage]:
+    prompt_input_values = {
+        "characters_objective": characters_objective,
+        "constructor_agent_logs": constructor_agent_logs,
+        "agent_scratchpad": validating_messages,
+    }
+
+    formatted_messages = chat_prompt_template.format_messages(**prompt_input_values)
+
+    return formatted_messages

--- a/backend/tests/character_agent_manual_test.py
+++ b/backend/tests/character_agent_manual_test.py
@@ -13,7 +13,7 @@ def print_step(title: str) -> None:
 
 if __name__ == "__main__":
     state = CharacterGraphState(
-        characters_global_narrative_context=(
+        characters_foundational_lore_document=(
             "a world where theres humanlike creatures (called Stoners) that are born with a stone incrustrated in their back. the stone keeps growing until they are crushed by its weight. some people that live freely and happy, their stone doesn't grow as fast. theres people that works mining other peoples stone with a pickaxe. when people dye, as the get crushed by its stone the only thing that remains in the surface is their stone, posing as a tombstone."
         ),
         characters_rules_and_constraints=[


### PR DESCRIPTION
## Summary
- extend `CharacterGraphState` with fields and structure that mirror `MapGraphState`
- add validation prompt and tools for characters
- implement validation and retry nodes for character agent
- update character orchestrator with a state graph similar to the map agent
- fix `SimulatedCharacters.get_initial_summary`
- adjust manual test to new field names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'subsystems.agents.character_handler.schemas.simulated_characters')*

------
https://chatgpt.com/codex/tasks/task_e_685d335337b0832e8e6335e733ab32bc