### PR TITLE
Add game session component with versioning

### DIFF
--- a/backend/core_game/game_state/domain.py
+++ b/backend/core_game/game_state/domain.py
@@ -74,6 +74,10 @@ class GameState:
     def update_map(self, map: GameMap) -> None:
         self._game_map = map
 
+    def update_session(self, session: GameSession) -> None:
+        """Update the game session component."""
+        self._session = session
+
 
 
 

--- a/backend/simulated/components/game_session.py
+++ b/backend/simulated/components/game_session.py
@@ -1,0 +1,56 @@
+from copy import deepcopy
+from typing import Any, Optional
+
+from core_game.game_session.domain import GameSession
+
+
+class SimulatedGameSession:
+    """Lightweight wrapper around :class:`GameSession` for isolated modifications."""
+
+    def __init__(self, session: GameSession) -> None:
+        self._working_state: GameSession = session
+
+    def __deepcopy__(self, memo):
+        copied_session = deepcopy(self._working_state)
+        return SimulatedGameSession(session=copied_session)
+
+    def get_state(self) -> GameSession:
+        return self._working_state
+
+    # ----- Modification methods -----
+    def set_user_prompt(self, prompt: str) -> None:
+        self._working_state._user_prompt = prompt
+
+    def set_refined_prompt(self, prompt: str) -> None:
+        self._working_state._refined_prompt = prompt
+
+    def set_player_main_goal(self, goal: str) -> None:
+        self._working_state._player_main_goal = goal
+
+    def set_global_flag(self, key: str, value: Any) -> None:
+        self._working_state._global_flags[key] = value
+
+    def remove_global_flag(self, key: str) -> None:
+        if key in self._working_state._global_flags:
+            del self._working_state._global_flags[key]
+        else:
+            raise KeyError(f"Global flag '{key}' not found.")
+
+    def advance_time(self, minutes: int) -> None:
+        self._working_state._time.advance(minutes)
+
+    # ----- Read methods -----
+    def get_user_prompt(self) -> Optional[str]:
+        return self._working_state._user_prompt
+
+    def get_refined_prompt(self) -> Optional[str]:
+        return self._working_state._refined_prompt
+
+    def get_player_main_goal(self) -> Optional[str]:
+        return self._working_state._player_main_goal
+
+    def get_global_flags(self) -> dict[str, Any]:
+        return dict(self._working_state._global_flags)
+
+    def get_time(self):
+        return self._working_state._time

--- a/backend/simulated/game_state.py
+++ b/backend/simulated/game_state.py
@@ -1,8 +1,8 @@
 
 from simulated.components.map import SimulatedMap
 from simulated.components.characters import SimulatedCharacters
-from simulated.versioning.layer import SimulationLayer
-from typing import List, Tuple, Optional
+from simulated.components.game_session import SimulatedGameSession
+from typing import List, Tuple, Optional, Any
 from core_game.character.schemas import PlayerCharacterModel, rollback_character_id
 from core_game.character.domain import PlayerCharacter, BaseCharacter
 from core_game.character.schemas import (
@@ -36,6 +36,14 @@ class SimulatedGameState:
     @property
     def _write_characters(self) -> SimulatedCharacters:
         return self._version_manager.get_current_characters(for_writing=True)
+
+    @property
+    def _read_session(self) -> SimulatedGameSession:
+        return self._version_manager.get_current_session(for_writing=False)
+
+    @property
+    def _write_session(self) -> SimulatedGameSession:
+        return self._version_manager.get_current_session(for_writing=True)
 
     # ---- MAP METHODS ------
 
@@ -119,6 +127,40 @@ class SimulatedGameState:
 
     def get_initial_characters_summary(self, *args, **kwargs):
         return self._read_characters.get_initial_summary(*args, **kwargs)
+
+    # ---- SESSION METHODS ----
+    def set_user_prompt(self, prompt: str) -> None:
+        self._write_session.set_user_prompt(prompt)
+
+    def set_refined_prompt(self, prompt: str) -> None:
+        self._write_session.set_refined_prompt(prompt)
+
+    def set_player_main_goal(self, goal: str) -> None:
+        self._write_session.set_player_main_goal(goal)
+
+    def set_global_flag(self, key: str, value: Any) -> None:
+        self._write_session.set_global_flag(key, value)
+
+    def remove_global_flag(self, key: str) -> None:
+        self._write_session.remove_global_flag(key)
+
+    def advance_time(self, minutes: int) -> None:
+        self._write_session.advance_time(minutes)
+
+    def get_user_prompt(self) -> Optional[str]:
+        return self._read_session.get_user_prompt()
+
+    def get_refined_prompt(self) -> Optional[str]:
+        return self._read_session.get_refined_prompt()
+
+    def get_player_main_goal(self) -> Optional[str]:
+        return self._read_session.get_player_main_goal()
+
+    def get_global_flags(self) -> dict[str, Any]:
+        return self._read_session.get_global_flags()
+
+    def get_time(self):
+        return self._read_session.get_time()
 
     # ---- MAP AND CHARACTER METHODS ----
     

--- a/backend/simulated/versioning/layer.py
+++ b/backend/simulated/versioning/layer.py
@@ -1,6 +1,7 @@
 from typing import Optional, TYPE_CHECKING
 from simulated.components.map import SimulatedMap
 from simulated.components.characters import SimulatedCharacters
+from simulated.components.game_session import SimulatedGameSession
 if TYPE_CHECKING:
     from simulated.versioning.manager import GameStateVersionManager
     from simulated.game_state import SimulatedGameState
@@ -16,6 +17,7 @@ class SimulationLayer:
         self._version_manager = version_manager
         self._map: Optional[SimulatedMap] = None
         self._characters: Optional[SimulatedCharacters] = None
+        self._session: Optional[SimulatedGameSession] = None
 
     @property
     def map(self) -> SimulatedMap:
@@ -34,6 +36,15 @@ class SimulationLayer:
             return self.parent.characters
         else:
             return self._version_manager.base_characters
+
+    @property
+    def session(self) -> SimulatedGameSession:
+        if self._session:
+            return self._session
+        elif self.parent:
+            return self.parent.session
+        else:
+            return self._version_manager.base_session
         
     def modify_map(self) -> SimulatedMap:
         if self._map is None:
@@ -44,6 +55,11 @@ class SimulationLayer:
         if self._characters is None:
             self._characters = deepcopy(self.characters)
         return self._characters
+
+    def modify_session(self) -> SimulatedGameSession:
+        if self._session is None:
+            self._session = deepcopy(self.session)
+        return self._session
     
     def has_modified_map(self) -> bool:
         return self._map is not None
@@ -57,8 +73,17 @@ class SimulationLayer:
     def has_modified_characters(self) -> bool:
         return self._characters is not None
 
+    def has_modified_session(self) -> bool:
+        return self._session is not None
+
     def get_modified_characters(self) -> SimulatedCharacters:
         return self._characters or self.characters
 
+    def get_modified_session(self) -> SimulatedGameSession:
+        return self._session or self.session
+
     def set_modified_characters(self, new_characters: SimulatedCharacters):
         self._characters = new_characters
+
+    def set_modified_session(self, new_session: SimulatedGameSession):
+        self._session = new_session


### PR DESCRIPTION
## Summary
- add `SimulatedGameSession` component to manage session data
- extend versioning system to track session changes
- expose session accessors and mutators in `SimulatedGameState`
- sync session updates with the domain game state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d51ace0d0832e88784f206735fdd6