### PR TITLE
Add refinement loop test pipelines and update main

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,26 +1,26 @@
-from subsystems.agents.map_handler.orchestrator import get_map_graph_app
-from subsystems.agents.map_handler.schemas.graph_state import MapGraphState
+"""Manual test entrypoint for the complete generation graph."""
+
+from subsystems.generation.orchestrator import get_generation_graph_app
+from subsystems.generation.schemas.graph_state import GenerationGraphState
+from subsystems.generation.refinement_loop.pipelines import map_then_characters_pipeline
 
 
-from simulated.game_state import SimulatedGameStateSingleton
-
-if __name__ == '__main__':
-    state = MapGraphState(
-        map_global_narrative_context="A small village of wizzards",
-        map_rules_and_constraints=["Every scenario must be connected to at least 1 other scenario.","Some scenarios must be connected to more than 2 other scenarios", "Spatial arrangement should make sense on a narrative and logical aspect, arrangement should be provokefull", "When traveling long or medium narrative distances between 2 scenarios, they should be connected by an intermidiate scenario that works as a path (road, path, valley, etc)"],
-        map_current_objective="Create a map of 5-7 scenarios. There should only be 1 cluster when finalized. Some scenarios (if posible more than 1) must be connected to more than 2 other scenarios",
-        map_other_guidelines="Make sure that any interior scenarios can be accessed through their corresponding exterior scenario, you can make a fully interior zone if needed. Some connection should have a condition to travel through, lore accurate",
-        map_max_executor_iterations=7,
-        map_max_validation_iterations=2,
-        map_max_retries=3
+if __name__ == "__main__":
+    pipeline = map_then_characters_pipeline()
+    state = GenerationGraphState(
+        initial_prompt=(
+            "A world where wizards live in a secluded valley and harness elemental magic."
+        ),
+        refined_prompt_desired_word_length=300,
+        refinement_pipeline_config=pipeline,
     )
-    print("--- INVOKE ---")
-    map_generation_app=get_map_graph_app()
-    final_state = map_generation_app.invoke(state,{"recursion_limit": 200})
-    final_map_graph_state_instance = MapGraphState(**final_state)
 
-    simulated_map = SimulatedGameStateSingleton.get_instance().simulated_map
+    print("--- INVOKE GENERATION GRAPH ---")
+    generation_app = get_generation_graph_app()
+    final_state_data = generation_app.invoke(state, {"recursion_limit": 200})
+    final_state = GenerationGraphState(**final_state_data)
 
-    print("\n--- FINAL STATE ---\n\n")
-    print(simulated_map.get_cluster_summary(True))
-
+    print("\n--- FINAL STATE ---\n")
+    print("Main goal:", final_state.main_goal)
+    print("Refined prompt:\n", final_state.refined_prompt)
+    print("Refinement log:", final_state.refinement_pass_changelog)

--- a/backend/subsystems/generation/refinement_loop/orchestrator.py
+++ b/backend/subsystems/generation/refinement_loop/orchestrator.py
@@ -35,7 +35,7 @@ def get_refinement_loop_graph_app():
     workflow = StateGraph(RefinementLoopGraphState)
     summarize_sub_graph = get_summarize_graph_app()
     map_agent_sub_graph = get_map_graph_app()
-    characters_agent_sub_graph = get_map_graph_app()
+    characters_agent_sub_graph = get_character_graph_app()
 
     workflow.add_node("start_refinement_loop", start_refinement_loop)
     workflow.add_node("map_agent", map_agent_sub_graph)

--- a/backend/subsystems/generation/refinement_loop/pipelines.py
+++ b/backend/subsystems/generation/refinement_loop/pipelines.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Predefined test pipelines for the refinement loop."""
+
+from .schemas.pipeline_config import PipelineConfig, PipelineStep
+from .constants import AgentName
+
+
+def map_only_pipeline() -> PipelineConfig:
+    """Single step pipeline that only runs the map agent."""
+    return PipelineConfig(
+        name="map_only",
+        description="Pipeline that runs only the map agent to generate a simple map.",
+        steps=[
+            PipelineStep(
+                step_name="Map Generation",
+                agent_name=AgentName.MAP,
+                objective_prompt="Create a small map with three connected scenarios.",
+                rules_and_constraints=[],
+                other_guidelines="Keep it brief.",
+                max_executor_iterations=3,
+                max_validation_iterations=1,
+                max_retries=0,
+            )
+        ],
+    )
+
+
+def characters_only_pipeline() -> PipelineConfig:
+    """Pipeline that runs only the character agent."""
+    return PipelineConfig(
+        name="characters_only",
+        description="Pipeline that creates a couple of characters in a single step.",
+        steps=[
+            PipelineStep(
+                step_name="Characters Generation",
+                agent_name=AgentName.CHARACTERS,
+                objective_prompt="Create two unique NPCs and the player character in the current map.",
+                rules_and_constraints=[],
+                other_guidelines="Keep them distinct and interesting.",
+                max_executor_iterations=3,
+                max_validation_iterations=1,
+                max_retries=0,
+            )
+        ],
+    )
+
+
+def map_then_characters_pipeline() -> PipelineConfig:
+    """Pipeline that first generates a map and then creates characters."""
+    return PipelineConfig(
+        name="map_then_characters",
+        description="Generates a map and then populates it with characters.",
+        steps=[
+            PipelineStep(
+                step_name="Initial Map",
+                agent_name=AgentName.MAP,
+                objective_prompt="Create a concise map with five scenarios all connected.",
+                rules_and_constraints=[],
+                other_guidelines="",
+                max_executor_iterations=4,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+            PipelineStep(
+                step_name="Add Characters",
+                agent_name=AgentName.CHARACTERS,
+                objective_prompt="Add interesting NPCs to the previously generated map.",
+                rules_and_constraints=[],
+                other_guidelines="Ensure the characters fit within the scenarios created.",
+                max_executor_iterations=3,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+        ],
+    )
+
+__all__ = [
+    "map_only_pipeline",
+    "characters_only_pipeline",
+    "map_then_characters_pipeline",
+]


### PR DESCRIPTION
## Summary
- implement basic test pipelines for the refinement loop
- fix character agent graph usage
- make `main.py` run the full generation graph using the new pipelines

## Testing
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_685d6e616aa0832e86b9d87db2df5346