### PR TITLE
Enable graph visualization from game state

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,8 @@
 from subsystems.generation.orchestrator import get_generation_graph_app
 from subsystems.generation.schemas.graph_state import GenerationGraphState
 from subsystems.generation.refinement_loop.pipelines import alternating_expansion_pipeline
+from utils.visualize_graph import visualize_map_graph
+from core_game.game_state.singleton import GameStateSingleton
 
 USER_PROMPT = """
 a world where theres humanlike creatures (called Stoners) that are born with a stone incrustrated in their back. the stone keeps growing until they are crushed by its weight. some people that live freely and happy, their stone doesn't grow as fast. theres people that works mining other peoples stone with a pickaxe. when people dye, as the get crushed by its stone the only thing that remains in the surface is their stone, posing as a tombstone
@@ -25,3 +27,6 @@ if __name__ == "__main__":
     print("Main goal:", final_state.main_goal)
     print("Refined prompt:\n", final_state.refined_prompt)
     print("Refinement log:", final_state.refinement_pass_changelog)
+
+    # Visualize the final map state
+    visualize_map_graph(GameStateSingleton.get_instance())

--- a/backend/utils/visualize_graph.py
+++ b/backend/utils/visualize_graph.py
@@ -1,82 +1,97 @@
 import networkx as nx
 import matplotlib.pyplot as plt
-from copy import deepcopy
 
-from subsystems.agents.map_handler.schemas.simulated_map import SimulatedMapModel
+from typing import Optional
 
-def visualize_map_graph(simulated_map: SimulatedMapModel):
+from core_game.game_state.domain import GameState
+from core_game.game_state.singleton import GameStateSingleton
+
+
+def visualize_map_graph(game_state: Optional[GameState] = None) -> None:
+    """Display the current map graph using NetworkX and Matplotlib.
+
+    Parameters
+    ----------
+    game_state:
+        The :class:`GameState` instance to visualize. If ``None`` (default),
+        the current instance provided by :class:`GameStateSingleton` will be
+        used.
     """
-    Visualiza el grafo de escenarios usando NetworkX y Matplotlib.
-    """
-    if not simulated_map.simulated_scenarios:
+
+    if game_state is None:
+        game_state = GameStateSingleton.get_instance()
+
+    game_map_model = game_state.game_map.to_model()
+    scenarios = game_map_model.scenarios
+    connections = game_map_model.connections
+
+    if not scenarios:
         print("No hay escenarios para visualizar.")
         return
 
-    G = nx.DiGraph()  # Usamos un grafo dirigido ya que las salidas tienen una dirección
+    G = nx.DiGraph()
 
-    # Añadir nodos
-    for scenario_id, scenario in simulated_map.simulated_scenarios.items():
-        # Usar getattr para más seguridad si algún atributo pudiera faltar
-        zone = getattr(scenario, 'zone', 'N/A')
-        indoor_outdoor = getattr(scenario, 'indoor_or_outdoor', 'N/A')
-        visual_desc = getattr(scenario, 'visual_description', 'N/A')
-        narrative_ctx = getattr(scenario, 'narrative_context', 'N/A')
-        
-        # Considera truncar visual_desc y narrative_ctx si son muy largos para la visualización
-        # Ejemplo:
-        # visual_desc_display = (visual_desc[:37] + '...') if len(visual_desc) > 40 else visual_desc
-        # narrative_ctx_display = (narrative_ctx[:37] + '...') if len(narrative_ctx) > 40 else narrative_ctx
+    for scenario_id, scenario in scenarios.items():
+        zone = getattr(scenario, "zone", "N/A")
+        indoor_outdoor = getattr(scenario, "indoor_or_outdoor", "N/A")
+        visual_desc = getattr(scenario, "visual_description", "N/A")
+        narrative_ctx = getattr(scenario, "narrative_context", "N/A")
 
-        G.add_node(scenario_id, name=scenario.name, 
-                   label=f"{scenario.name}\n({scenario_id})\nZone: {zone}\nIndoor/Outdoor: {indoor_outdoor}\nVisual: {visual_desc}\nNarrative: {narrative_ctx}")
+        G.add_node(
+            scenario_id,
+            name=scenario.name,
+            label=(
+                f"{scenario.name}\n({scenario_id})\nZone: {zone}\n"
+                f"Indoor/Outdoor: {indoor_outdoor}\nVisual: {visual_desc}\n"
+                f"Narrative: {narrative_ctx}"
+            ),
+        )
 
-    # Añadir aristas (conexiones)
     edge_labels = {}
-    for scenario_id, scenario in simulated_map.simulated_scenarios.items():
+    for scenario_id, scenario in scenarios.items():
         for direction, conn_id in scenario.connections.items():
             if not conn_id:
                 continue
-            conn = simulated_map.simulated_connections.get(conn_id)
-            if conn:
-                target_id = conn.scenario_b_id if conn.scenario_a_id == scenario_id else conn.scenario_a_id
-                if target_id in simulated_map.simulated_scenarios:
-                    G.add_edge(scenario_id, target_id)
-                    edge_labels[(scenario_id, target_id)] = f"{direction}\n({conn.connection_type})"
-                else:
-                    print(f"Advertencia: El escenario '{scenario_id}' tiene una conexión a un escenario no existente '{target_id}'.")
+            conn = connections.get(conn_id)
+            if not conn:
+                continue
+            target_id = conn.scenario_b_id if conn.scenario_a_id == scenario_id else conn.scenario_a_id
+            if target_id in scenarios:
+                G.add_edge(scenario_id, target_id)
+                edge_labels[(scenario_id, target_id)] = f"{direction}\n({conn.connection_type})"
+            else:
+                print(
+                    f"Advertencia: El escenario '{scenario_id}' tiene una conexión a un escenario no existente '{target_id}'."
+                )
 
     if not G.nodes():
         print("Grafo vacío después de procesar escenarios.")
         return
 
-    plt.figure(figsize=(16, 12)) # Un poco más grande por si hay mucho texto
-    
+    plt.figure(figsize=(16, 12))
+
     try:
-        pos = nx.spring_layout(G, k=1.2, iterations=50, seed=42) # Ajustar k y añadir seed para reproducibilidad
-    except Exception: 
+        pos = nx.spring_layout(G, k=1.2, iterations=50, seed=42)
+    except Exception:
         pos = nx.kamada_kawai_layout(G)
 
-    node_labels_from_graph = {node: data['label'] for node, data in G.nodes(data=True)}
-    # Ajusta node_size y font_size según necesites
-    nx.draw_networkx_nodes(G, pos, node_size=3500, node_color="skyblue", alpha=0.9)
-    
-    nx.draw_networkx_edges(G, pos, edgelist=G.edges(), arrowstyle="->", arrowsize=20, 
-                           edge_color="gray", alpha=0.7, node_size=3500) 
-    
-    nx.draw_networkx_labels(G, pos, labels=node_labels_from_graph, font_size=7) # Fuente más pequeña para nodos
+    node_labels_from_graph = {node: data["label"] for node, data in G.nodes(data=True)}
 
-    # --- ¡AQUÍ AÑADES LAS ETIQUETAS DE LAS ARISTAS! ---
-    nx.draw_networkx_edge_labels(
-        G, pos,
-        edge_labels=edge_labels,
-        font_color='red', # Puedes cambiar el color para distinguirlas
-        font_size=6,      # Ajusta el tamaño de la fuente
-        # rotate=False,   # Para evitar que las etiquetas roten con el ángulo de la arista
-        # label_pos=0.3   # Ajusta la posición de la etiqueta a lo largo de la arista (0=origen, 0.5=medio, 1=destino)
+    nx.draw_networkx_nodes(G, pos, node_size=3500, node_color="skyblue", alpha=0.9)
+    nx.draw_networkx_edges(
+        G,
+        pos,
+        edgelist=G.edges(),
+        arrowstyle="->",
+        arrowsize=20,
+        edge_color="gray",
+        alpha=0.7,
+        node_size=3500,
     )
-    # ----------------------------------------------------
+    nx.draw_networkx_labels(G, pos, labels=node_labels_from_graph, font_size=7)
+    nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels, font_color="red", font_size=6)
 
     plt.title("Visualización del Mapa de Escenarios", fontsize=16)
-    plt.axis('off') 
+    plt.axis("off")
     plt.tight_layout()
     plt.show()


### PR DESCRIPTION
## Summary
- pull map data directly from `GameState` instead of simulated layer
- update `main` to use `GameStateSingleton` for final graph view

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685e614a7200832e9c92c223c4e6d784