### PR TITLE
Add manual tests for name_contains filter

### DIFF
--- a/backend/tests/character_execution_tools_manual_test.py
+++ b/backend/tests/character_execution_tools_manual_test.py
@@ -230,6 +230,17 @@ if __name__ == "__main__":
         )
     )
 
+    print_step("Filter By Name Contains")
+    print(
+        list_characters.invoke(
+            {
+                "simulated_characters_state": characters_state,
+                "attribute_to_filter": "name_contains",
+                "value_to_match": "the",
+            }
+        )
+    )
+
     print_step("Player Details")
     print(
         get_player_details.invoke(

--- a/backend/tests/map_execution_tools_manual_test.py
+++ b/backend/tests/map_execution_tools_manual_test.py
@@ -132,6 +132,15 @@ if __name__ == "__main__":
         simulated_map_state=simulated_map,
     ))
 
+    print_step("Find Scenarios by Name Contains")
+    find_name_args = FindScenariosArgs(attribute_to_filter="name_contains", value_to_match="Forest")
+    print(find_scenarios_by_attribute(
+        attribute_to_filter=find_name_args.attribute_to_filter,
+        value_to_match=find_name_args.value_to_match,
+        max_results=find_name_args.max_results,
+        simulated_map_state=simulated_map,
+    ))
+
     # === SPATIAL INFO ===
     print_step("SPATIAL INFO")
     spatialinfo_args = GetNeighborsAtDistanceArgs(start_scenario_id="scene_002",max_distance=3)


### PR DESCRIPTION
## Summary
- extend `character_execution_tools_manual_test.py` with a name_contains filter step
- extend `map_execution_tools_manual_test.py` with a name_contains filter step

## Testing
- `PYTHONPATH=$PWD/backend python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_6862979642ec832eadaca49318f5a644