### PR TITLE
Require intensity in relationships

### DIFF
--- a/backend/core_game/relationship/domain.py
+++ b/backend/core_game/relationship/domain.py
@@ -25,7 +25,7 @@ class CharacterRelationship:
         return self._data.type
 
     @property
-    def intensity(self) -> Optional[int]:
+    def intensity(self) -> int:
         return self._data.intensity
 
     def get_model(self) -> CharacterRelationshipModel:

--- a/backend/core_game/relationship/schemas.py
+++ b/backend/core_game/relationship/schemas.py
@@ -22,17 +22,17 @@ class CharacterRelationshipModel(BaseModel):
     - 0: Total absence or neutrality of the relationship. It does NOT mean the opposite. For example, 'love' with an intensity of 0 means there is no love, but it does NOT imply hate.
     - 10: Maximum possible intensity. For example, 'love' with an intensity of 10 means being completely in love.
     
-    For relationships that do not have a measurable intensity (such as 'siblings' or 'parent'), the intensity can be None.
+    Every relationship must have an intensity, measured on a scale from 0 to 10.
     """
     type: RelationshipTypeModel = Field(
         ...,
         description="The type of relationship being measured."
     )
-    intensity: Optional[int] = Field(
-        default=None,
+    intensity: int = Field(
+        ...,
         ge=0,
         le=10,
-        description="Level of the relationship on a scale of 0 (neutral/absence) to 10 (maximum). It is None if the relationship does not have an intensity."
+        description="Level of the relationship on a scale of 0 (neutral/absence) to 10 (maximum)."
     )
 
 class RelationshipsModel(BaseModel):

--- a/backend/simulated/components/relationships.py
+++ b/backend/simulated/components/relationships.py
@@ -47,7 +47,7 @@ class SimulatedRelationships:
         source_character_id: str,
         target_character_id: str,
         relationship_type: str,
-        intensity: Optional[int] = None,
+        intensity: int,
     ) -> CharacterRelationship:
         if relationship_type not in self._working_state._relationship_types:
             raise ValueError(f"Unknown relationship type '{relationship_type}'.")
@@ -64,7 +64,7 @@ class SimulatedRelationships:
         character_a_id: str,
         character_b_id: str,
         relationship_type: str,
-        intensity: Optional[int] = None,
+        intensity: int,
     ) -> None:
         self.create_directed_relationship(character_a_id, character_b_id, relationship_type, intensity)
         self.create_directed_relationship(character_b_id, character_a_id, relationship_type, intensity)
@@ -80,8 +80,6 @@ class SimulatedRelationships:
             rel = self._working_state._matrix[source_character_id][target_character_id][relationship_type]
         except KeyError as exc:
             raise KeyError("Relationship not found") from exc
-        if rel.get_model().intensity is None:
-            raise ValueError("Relationship has no intensity to modify.")
         rel._data.intensity = new_intensity
 
     # ---- Read methods ----

--- a/backend/subsystems/agents/relationship_handler/tools/relationship_tools.py
+++ b/backend/subsystems/agents/relationship_handler/tools/relationship_tools.py
@@ -27,13 +27,14 @@ class ToolCreateDirectedRelationshipArgs(InjectedToolContext):
         ..., description="ID of the character receiving the relationship"
     )
     relationship_type: str = Field(
-        ..., description="Name of the relationship type to create"
+        ...,
+        description="Name of an existing relationship type. Use 'create_relationship_type' first if needed"
     )
-    intensity: Optional[int] = Field(
-        default=None,
+    intensity: int = Field(
+        ...,
         ge=0,
         le=10,
-        description="Optional intensity value from 0 to 10",
+        description="Intensity value from 0 to 10",
     )
 
 class ToolCreateUndirectedRelationshipArgs(InjectedToolContext):
@@ -44,13 +45,14 @@ class ToolCreateUndirectedRelationshipArgs(InjectedToolContext):
         ..., description="ID of the second character in the relationship"
     )
     relationship_type: str = Field(
-        ..., description="Name of the relationship type to create"
+        ...,
+        description="Name of an existing relationship type. Use 'create_relationship_type' first if needed"
     )
-    intensity: Optional[int] = Field(
-        default=None,
+    intensity: int = Field(
+        ...,
         ge=0,
         le=10,
-        description="Optional intensity value from 0 to 10",
+        description="Intensity value from 0 to 10",
     )
 
 class ToolModifyRelationshipIntensityArgs(InjectedToolContext):
@@ -109,12 +111,12 @@ def create_directed_relationship(
     source_character_id: str,
     target_character_id: str,
     relationship_type: str,
-    intensity: Optional[int],
+    intensity: int,
     messages_field_to_update: Annotated[str, InjectedState("messages_field_to_update")],
     logs_field_to_update: Annotated[str, InjectedState("logs_field_to_update")],
     tool_call_id: Annotated[str, InjectedToolCallId],
 ) -> Command:
-    """Create a directed relationship between two characters."""
+    """Create a directed relationship between two characters. The relationship type must already exist."""
     args = extract_tool_args(locals())
     simulated_state = SimulatedGameStateSingleton.get_instance()
     success = True
@@ -139,12 +141,12 @@ def create_undirected_relationship(
     character_a_id: str,
     character_b_id: str,
     relationship_type: str,
-    intensity: Optional[int],
+    intensity: int,
     messages_field_to_update: Annotated[str, InjectedState("messages_field_to_update")],
     logs_field_to_update: Annotated[str, InjectedState("logs_field_to_update")],
     tool_call_id: Annotated[str, InjectedToolCallId],
 ) -> Command:
-    """Create an undirected relationship between two characters."""
+    """Create an undirected relationship between two characters. The relationship type must already exist."""
     args = extract_tool_args(locals())
     simulated_state = SimulatedGameStateSingleton.get_instance()
     success = True


### PR DESCRIPTION
## Summary
- enforce mandatory intensity value in relationship schemas and domain model
- update relationship tools and simulation component to require intensity and clarify existing type usage
- improve tool docstrings to indicate that relationship types must already exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e4016ce4832eb909e462bbb5dc59