### PR TITLE
Add relationship agent summary and transaction handling

### DIFF
--- a/backend/simulated/components/relationships.py
+++ b/backend/simulated/components/relationships.py
@@ -94,3 +94,28 @@ class SimulatedRelationships:
             for rels in nested.values():
                 count += len(rels)
         return count
+
+    def get_initial_summary(self) -> str:
+        """Return a brief summary of existing relationship data."""
+        rel_types = ", ".join(self._working_state._relationship_types.keys())
+        if not rel_types:
+            rel_types = "None"
+
+        character_counts: Dict[str, int] = {}
+        for src, nested in self._working_state._matrix.items():
+            for tgt, rels in nested.items():
+                count = len(rels)
+                character_counts[src] = character_counts.get(src, 0) + count
+                character_counts[tgt] = character_counts.get(tgt, 0) + count
+
+        if not character_counts:
+            relationships_summary = "No relationships created yet"
+        else:
+            relationships_summary = ", ".join(
+                f"{cid}: {cnt}" for cid, cnt in character_counts.items()
+            )
+
+        return (
+            f"Relationship types: {rel_types}. "
+            f"Relationships per character: {relationships_summary}"
+        )

--- a/backend/simulated/game_state.py
+++ b/backend/simulated/game_state.py
@@ -159,6 +159,9 @@ class SimulatedGameState:
     def get_relationship_count(self) -> int:
         return self._read_relationships.relationship_count()
 
+    def get_initial_relationships_summary(self) -> str:
+        return self._read_relationships.get_initial_summary()
+
     # ---- SESSION METHODS ----
     def set_user_prompt(self, prompt: str) -> None:
         self._write_session.set_user_prompt(prompt)

--- a/backend/subsystems/agents/relationship_handler/nodes.py
+++ b/backend/subsystems/agents/relationship_handler/nodes.py
@@ -12,11 +12,16 @@ from utils.message_window import get_valid_messages_window
 from langchain_core.messages import BaseMessage, HumanMessage, RemoveMessage
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from subsystems.agents.utils.logs import ToolLog
+from simulated.singleton import SimulatedGameStateSingleton
 
 
 def receive_objective_node(state: RelationshipGraphState):
     print("---ENTERING: RECEIVE OBJECTIVE NODE---")
-    initial_summary = "No relationships defined yet."
+    SimulatedGameStateSingleton.begin_transaction()
+    initial_summary = (
+        SimulatedGameStateSingleton.get_instance()
+        .get_initial_relationships_summary()
+    )
     return {
         "relationships_current_try": 0,
         "messages_field_to_update": "relationships_executor_messages",
@@ -120,6 +125,7 @@ def retry_executor_node(state: RelationshipGraphState):
 
 def final_node_success(state: RelationshipGraphState):
     print("---ENTERING: LAST NODE OBJECTIVE SUCCESS---")
+    SimulatedGameStateSingleton.commit()
     return {
         "relationships_task_succeeded_final": True,
     }
@@ -127,6 +133,7 @@ def final_node_success(state: RelationshipGraphState):
 
 def final_node_failure(state: RelationshipGraphState):
     print("---ENTERING: LAST NODE OBJECTIVE FAILED---")
+    SimulatedGameStateSingleton.rollback()
     return {
         "relationships_task_succeeded_final": False,
     }

--- a/backend/subsystems/generation/refinement_loop/nodes.py
+++ b/backend/subsystems/generation/refinement_loop/nodes.py
@@ -105,6 +105,35 @@ def characters_step_finish(state: RefinementLoopGraphState):
         "last_step_succeeded": state.characters_task_succeeded_final
     }
 
+def relationship_step_start(state: RefinementLoopGraphState):
+    """Sets up the state for the pass to refine the relationships"""
+
+    applied_operations_log = "Old operations summary: " + state.changelog_old_operations_summary + "Most recent operations:" + format_window(6, state.refinement_pass_changelog)
+    relevant_entities_str = ""
+    additional_info_str = ""
+    current_step = state.refinement_pipeline_config.steps[state.refinement_current_pass]
+    return {
+        "relationships_foundational_lore_document": state.refinement_foundational_world_info,
+        "relationships_recent_operations_summary": applied_operations_log,
+        "relationships_relevant_entity_details": relevant_entities_str,
+        "relationships_additional_information": additional_info_str,
+        "relationships_rules_and_constraints": current_step.rules_and_constraints,
+        "relationships_other_guidelines": current_step.other_guidelines,
+        "relationships_current_objective": current_step.objective_prompt,
+        "relationships_max_executor_iterations": current_step.max_executor_iterations,
+        "relationships_max_validation_iterations": current_step.max_validation_iterations,
+        "relationships_max_retries": current_step.max_retries,
+        "relationships_executor_applied_operations_log": ClearLogs(),
+        "relationships_validator_applied_operations_log": ClearLogs(),
+    }
+
+def relationship_step_finish(state: RefinementLoopGraphState):
+    """Postprocesses the finished relationship step."""
+    return {
+        "operations_log_to_summarize": state.relationships_executor_applied_operations_log,
+        "last_step_succeeded": state.relationships_task_succeeded_final,
+    }
+
 
 def finalize_step(state: RefinementLoopGraphState):
     """

--- a/backend/subsystems/generation/refinement_loop/orchestrator.py
+++ b/backend/subsystems/generation/refinement_loop/orchestrator.py
@@ -7,6 +7,7 @@ from subsystems.summarize_agent_logs.orchestrator import get_summarize_graph_app
 from subsystems.generation.refinement_loop.constants import AgentName
 from subsystems.agents.map_handler.orchestrator import get_map_graph_app
 from subsystems.agents.character_handler.orchestrator import get_character_graph_app
+from subsystems.agents.relationship_handler.orchestrator import get_relationship_graph_app
 
 def go_to_next_agent_or_finish(state: RefinementLoopGraphState) -> Union[AgentName, Literal["finalize"]]:
     """
@@ -36,6 +37,7 @@ def get_refinement_loop_graph_app():
     summarize_sub_graph = get_summarize_graph_app()
     map_agent_sub_graph = get_map_graph_app()
     characters_agent_sub_graph = get_character_graph_app()
+    relationship_agent_sub_graph = get_relationship_graph_app()
 
     workflow.add_node("start_refinement_loop", start_refinement_loop)
     workflow.add_node("map_agent", map_agent_sub_graph)
@@ -44,6 +46,9 @@ def get_refinement_loop_graph_app():
     workflow.add_node("characters_agent", characters_agent_sub_graph)
     workflow.add_node("characters_step_start", characters_step_start)
     workflow.add_node("characters_step_finish", characters_step_finish)
+    workflow.add_node("relationship_agent", relationship_agent_sub_graph)
+    workflow.add_node("relationship_step_start", relationship_step_start)
+    workflow.add_node("relationship_step_finish", relationship_step_finish)
     workflow.add_node("finalize_step", finalize_step)
     workflow.add_node("prepare_next_step", prepare_next_step)
     workflow.add_node("summarize_agent_logs", summarize_sub_graph)
@@ -58,6 +63,7 @@ def get_refinement_loop_graph_app():
         {
             AgentName.MAP: "map_step_start",
             AgentName.CHARACTERS: "characters_step_start",
+            AgentName.RELATIONSHIP: "relationship_step_start",
             "finalize": END,
         }
     )
@@ -68,6 +74,7 @@ def get_refinement_loop_graph_app():
         {
             AgentName.MAP: "map_step_start",
             AgentName.CHARACTERS: "characters_step_start",
+            AgentName.RELATIONSHIP: "relationship_step_start",
             "finalize": END,
         }
     )
@@ -80,6 +87,10 @@ def get_refinement_loop_graph_app():
     workflow.add_edge("characters_step_start", "characters_agent")
     workflow.add_edge("characters_agent", "characters_step_finish")
     workflow.add_edge("characters_step_finish", "finalize_step")
+
+    workflow.add_edge("relationship_step_start", "relationship_agent")
+    workflow.add_edge("relationship_agent", "relationship_step_finish")
+    workflow.add_edge("relationship_step_finish", "finalize_step")
 
     workflow.add_conditional_edges(
         "finalize_step",

--- a/backend/subsystems/generation/refinement_loop/pipelines.py
+++ b/backend/subsystems/generation/refinement_loop/pipelines.py
@@ -75,6 +75,46 @@ def map_then_characters_pipeline() -> PipelineConfig:
         ],
     )
 
+
+def map_characters_relationships_pipeline() -> PipelineConfig:
+    """Pipeline that generates a map, then characters and finally relationships."""
+    return PipelineConfig(
+        name="map_characters_relationships",
+        description="Generates a map and characters first and then establishes relationships between them.",
+        steps=[
+            PipelineStep(
+                step_name="Initial Map",
+                agent_name=AgentName.MAP,
+                objective_prompt="Create a concise map with three connected scenarios.",
+                rules_and_constraints=[],
+                other_guidelines="",
+                max_executor_iterations=4,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+            PipelineStep(
+                step_name="Add Characters",
+                agent_name=AgentName.CHARACTERS,
+                objective_prompt="Introduce two characters placed in the generated scenarios.",
+                rules_and_constraints=[],
+                other_guidelines="",
+                max_executor_iterations=3,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+            PipelineStep(
+                step_name="Create Relationships",
+                agent_name=AgentName.RELATIONSHIP,
+                objective_prompt="Create interesting relationships between the characters.",
+                rules_and_constraints=[],
+                other_guidelines="Ensure the relationships make sense with the character backgrounds and map.",
+                max_executor_iterations=3,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+        ],
+    )
+
 def alternating_expansion_pipeline() -> PipelineConfig:
     """Pipeline with six steps alternating between map and characters."""
 
@@ -122,4 +162,5 @@ __all__ = [
     "characters_only_pipeline",
     "map_then_characters_pipeline",
     "alternating_expansion_pipeline",
+    "map_characters_relationships_pipeline",
 ]

--- a/backend/subsystems/generation/refinement_loop/schemas/graph_state.py
+++ b/backend/subsystems/generation/refinement_loop/schemas/graph_state.py
@@ -6,9 +6,10 @@ from pydantic import BaseModel, Field
 from subsystems.generation.refinement_loop.schemas.pipeline_config import PipelineConfig
 from subsystems.agents.character_handler.schemas.graph_state import CharacterGraphState
 from subsystems.agents.map_handler.schemas.graph_state import MapGraphState
+from subsystems.agents.relationship_handler.schemas.graph_state import RelationshipGraphState
 from subsystems.summarize_agent_logs.schemas.graph_state import SummarizeLogsGraphState
 from subsystems.agents.utils.schemas import AgentLog
-class RefinementLoopGraphState(CharacterGraphState, MapGraphState, SummarizeLogsGraphState):
+class RefinementLoopGraphState(CharacterGraphState, MapGraphState, RelationshipGraphState, SummarizeLogsGraphState):
     """
     Manages the state of the iterative N-pass enrichment loop.
     """


### PR DESCRIPTION
## Summary
- add relationship summary helper in SimulatedRelationships
- expose `get_initial_relationships_summary` in SimulatedGameState
- include summary in relationship agent's first node and handle transactions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e6c6de14832e811457a500f55b26