### PR TITLE
Add narrative initial stage summary

### DIFF
--- a/backend/core_game/game_state/domain.py
+++ b/backend/core_game/game_state/domain.py
@@ -6,7 +6,7 @@ from core_game.map.domain import GameMap
 from core_game.character.domain import Characters
 from core_game.game_state.schemas import GameStateModel
 from core_game.time.domain import GameTime
-from core_game.narrative.schemas import NarrativeStateModel
+from core_game.narrative.domain import NarrativeState
 from core_game.game_event.schemas import GameEventModel
 from core_game.relationship.domain import Relationships
 from core_game.game_session.domain import GameSession
@@ -19,7 +19,7 @@ class GameState:
         self._game_map: GameMap
         self._characters: Characters
         self._relationships: Relationships
-        self._narrative_state: NarrativeStateModel
+        self._narrative_state: NarrativeState
         self._game_event_log: List[GameEventModel]
 
         if game_state_model is not None:
@@ -29,7 +29,7 @@ class GameState:
             self._game_map = GameMap()
             self._characters = Characters()
             self._relationships = Relationships()
-            #self._narrative_state = NarrativeStateModel()
+            self._narrative_state = NarrativeState()
             self._game_event_log = []
 
 
@@ -49,6 +49,10 @@ class GameState:
     def relationships(self) -> Relationships:
         return self._relationships
 
+    @property
+    def narrative_state(self) -> NarrativeState:
+        return self._narrative_state
+
 
     def _populate_from_model(self, game_state_model: GameStateModel) -> None:
         """Populate the domain state from a :class:`GameStateModel`."""
@@ -57,7 +61,7 @@ class GameState:
         self._game_map = GameMap(game_state_model.game_map)
         self._characters = Characters(game_state_model.characters)
         self._relationships = Relationships(game_state_model.relationships)
-        self._narrative_state = game_state_model.narrative_state
+        self._narrative_state = NarrativeState(game_state_model.narrative_state)
         self._game_event_log = game_state_model.game_event_log
 
     def load_from_file(self, file_path: str = "game_state.json") -> None:
@@ -84,6 +88,9 @@ class GameState:
 
     def update_relationships(self, relationships: Relationships) -> None:
         self._relationships = relationships
+
+    def update_narrative_state(self, narrative_state: NarrativeState) -> None:
+        self._narrative_state = narrative_state
 
 
 

--- a/backend/core_game/narrative/domain.py
+++ b/backend/core_game/narrative/domain.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+from typing import Optional
+from core_game.narrative.schemas import (
+    NarrativeStateModel,
+    NarrativeBeatModel,
+    FailureConditionModel,
+    RiskTriggeredBeats,
+    NarrativeStageModel,
+    NarrativeStructureModel,
+)
+from core_game.narrative.structures import AVAILABLE_NARRATIVE_STRUCTURES
+
+class NarrativeState:
+    """Domain wrapper around :class:`NarrativeStateModel`."""
+
+    def __init__(self, model: Optional[NarrativeStateModel] = None) -> None:
+        if model:
+            self._data = model
+        else:
+            # create a default narrative state using the first available structure
+            structure_type = AVAILABLE_NARRATIVE_STRUCTURES[0]
+            stages = [
+                NarrativeStageModel(**stage.model_dump(), stage_beats=[])
+                for stage in structure_type.stages
+            ]
+            structure = NarrativeStructureModel(structure_type=structure_type, stages=stages)
+            self._data = NarrativeStateModel(
+                main_goal=None,
+                failure_conditions=[],
+                current_stage_index=0,
+                narrative_structure=structure,
+            )
+
+    # ------------------------------------------------------------------
+    # Conversion helpers
+    # ------------------------------------------------------------------
+    def to_model(self) -> NarrativeStateModel:
+        return self._data
+
+    # ------------------------------------------------------------------
+    # Accessor properties
+    # ------------------------------------------------------------------
+    @property
+    def narrative_structure(self) -> NarrativeStructureModel:
+        return self._data.narrative_structure
+
+    @property
+    def failure_conditions(self) -> list[FailureConditionModel]:
+        return self._data.failure_conditions
+
+    # ------------------------------------------------------------------
+    # Modification methods
+    # ------------------------------------------------------------------
+    def add_narrative_beat(self, stage_index: int, beat: NarrativeBeatModel) -> None:
+        stages = self._data.narrative_structure.stages
+        if stage_index < 0 or stage_index >= len(stages):
+            raise IndexError("Stage index out of range")
+        stages[stage_index].stage_beats.append(beat)
+
+    def add_failure_condition(self, failure_condition: FailureConditionModel) -> None:
+        self._data.failure_conditions.append(failure_condition)
+
+    def _find_failure(self, condition_id: str) -> FailureConditionModel:
+        for cond in self._data.failure_conditions:
+            if cond.id == condition_id:
+                return cond
+        raise KeyError(f"Failure condition '{condition_id}' not found")
+
+    def add_risk_triggered_beats(self, condition_id: str, risk_triggered: RiskTriggeredBeats) -> None:
+        cond = self._find_failure(condition_id)
+        cond.risk_triggered_beats.append(risk_triggered)
+
+    def set_failure_risk_level(self, condition_id: str, risk_level: int) -> None:
+        cond = self._find_failure(condition_id)
+        risk_level = max(0, min(100, risk_level))
+        cond.risk_level = risk_level
+        cond.is_active = risk_level >= 100
+        for rtb in cond.risk_triggered_beats:
+            for beat in rtb.beats:
+                if risk_level >= rtb.trigger_risk_level:
+                    beat.status = "ACTIVE"
+                if risk_level <= rtb.deactivate_risk_level:
+                    beat.status = "PENDING"
+
+    # ------------------------------------------------------------------
+    # Summary helpers
+    # ------------------------------------------------------------------
+    def get_initial_summary(self) -> str:
+        """Return the current stage and beats summary."""
+        stage_index = self._data.current_stage_index or 0
+        stages = self._data.narrative_structure.stages
+        if stage_index < 0 or stage_index >= len(stages):
+            return "No current narrative stage"
+        stage = stages[stage_index]
+        if stage.stage_beats:
+            beats_summary = ", ".join(
+                f"{b.id} [{b.status}]" for b in stage.stage_beats
+            )
+        else:
+            beats_summary = "No beats yet"
+        return f"Current stage: {stage.name}. Beats: {beats_summary}"
+

--- a/backend/simulated/components/__init__.py
+++ b/backend/simulated/components/__init__.py
@@ -2,10 +2,12 @@ from .characters import SimulatedCharacters
 from .map import SimulatedMap
 from .game_session import SimulatedGameSession
 from .relationships import SimulatedRelationships
+from .narrative import SimulatedNarrative
 
 __all__ = [
     "SimulatedCharacters",
     "SimulatedMap",
     "SimulatedGameSession",
     "SimulatedRelationships",
+    "SimulatedNarrative",
 ]

--- a/backend/simulated/components/narrative.py
+++ b/backend/simulated/components/narrative.py
@@ -1,0 +1,61 @@
+from copy import deepcopy
+from typing import List
+from core_game.narrative.schemas import (
+    NarrativeBeatModel,
+    FailureConditionModel,
+    RiskTriggeredBeats,
+)
+from core_game.narrative.domain import NarrativeState
+
+class SimulatedNarrative:
+    """Lightweight wrapper around :class:`NarrativeState`."""
+
+    def __init__(self, narrative_state: NarrativeState) -> None:
+        self._working_state: NarrativeState = narrative_state
+
+    def __deepcopy__(self, memo):
+        copied_state = NarrativeState(model=deepcopy(self._working_state.to_model()))
+        return SimulatedNarrative(copied_state)
+
+    def get_state(self) -> NarrativeState:
+        return self._working_state
+
+    def get_initial_summary(self) -> str:
+        """Return summary info about the current narrative stage."""
+        return self._working_state.get_initial_summary()
+
+    # ---- Narrative beat management ----
+    def add_narrative_beat(self, stage_index: int, beat: NarrativeBeatModel) -> None:
+        stages = self._working_state.narrative_structure.stages
+        if stage_index < 0 or stage_index >= len(stages):
+            raise IndexError("Stage index out of range")
+        stages[stage_index].stage_beats.append(beat)
+
+    def add_failure_condition(self, failure_condition: FailureConditionModel) -> None:
+        self._working_state.failure_conditions.append(failure_condition)
+
+    def _find_failure(self, condition_id: str) -> FailureConditionModel:
+        for cond in self._working_state.failure_conditions:
+            if cond.id == condition_id:
+                return cond
+        raise KeyError(f"Failure condition '{condition_id}' not found")
+
+    def add_risk_triggered_beats(
+        self,
+        condition_id: str,
+        risk_triggered: RiskTriggeredBeats,
+    ) -> None:
+        cond = self._find_failure(condition_id)
+        cond.risk_triggered_beats.append(risk_triggered)
+
+    def set_failure_risk_level(self, condition_id: str, risk_level: int) -> None:
+        cond = self._find_failure(condition_id)
+        risk_level = max(0, min(100, risk_level))
+        cond.risk_level = risk_level
+        cond.is_active = risk_level >= 100
+        for rtb in cond.risk_triggered_beats:
+            for beat in rtb.beats:
+                if risk_level >= rtb.trigger_risk_level:
+                    beat.status = "ACTIVE"
+                if risk_level <= rtb.deactivate_risk_level:
+                    beat.status = "PENDING"

--- a/backend/simulated/game_state.py
+++ b/backend/simulated/game_state.py
@@ -3,6 +3,7 @@ from simulated.components.map import SimulatedMap
 from simulated.components.characters import SimulatedCharacters
 from simulated.components.game_session import SimulatedGameSession
 from simulated.components.relationships import SimulatedRelationships
+from simulated.components.narrative import SimulatedNarrative
 from typing import List, Tuple, Optional, Any
 from core_game.character.schemas import PlayerCharacterModel, rollback_character_id
 from core_game.character.domain import PlayerCharacter, BaseCharacter
@@ -10,6 +11,11 @@ from core_game.character.schemas import (
     IdentityModel, PhysicalAttributesModel, PsychologicalAttributesModel, KnowledgeModel
 )
 from core_game.map.domain import Scenario
+from core_game.narrative.schemas import (
+    NarrativeBeatModel,
+    FailureConditionModel,
+    RiskTriggeredBeats,
+)
 from simulated.versioning.manager import GameStateVersionManager
 
 class SimulatedGameState:
@@ -45,6 +51,14 @@ class SimulatedGameState:
     @property
     def _write_relationships(self) -> SimulatedRelationships:
         return self._version_manager.get_current_relationships(for_writing=True)
+
+    @property
+    def _read_narrative(self) -> SimulatedNarrative:
+        return self._version_manager.get_current_narrative(for_writing=False)
+
+    @property
+    def _write_narrative(self) -> SimulatedNarrative:
+        return self._version_manager.get_current_narrative(for_writing=True)
 
     @property
     def _read_session(self) -> SimulatedGameSession:
@@ -195,6 +209,27 @@ class SimulatedGameState:
 
     def get_time(self):
         return self._read_session.get_time()
+
+    # ---- NARRATIVE METHODS ----
+    def get_initial_narrative_summary(self) -> str:
+        return self._read_narrative.get_initial_summary()
+    def add_narrative_beat(self, stage_index: int, beat: NarrativeBeatModel) -> None:
+        self._write_narrative.add_narrative_beat(stage_index, beat)
+
+    def add_failure_condition(self, failure_condition: FailureConditionModel) -> None:
+        self._write_narrative.add_failure_condition(failure_condition)
+
+    def add_risk_triggered_beats(self, condition_id: str, risk_triggered: RiskTriggeredBeats) -> None:
+        self._write_narrative.add_risk_triggered_beats(condition_id, risk_triggered)
+
+    def set_failure_risk_level(self, condition_id: str, risk_level: int) -> None:
+        self._write_narrative.set_failure_risk_level(condition_id, risk_level)
+
+    def get_current_stage_beats(self, stage_index: int):
+        stages = self._read_narrative.get_state().narrative_structure.stages
+        if stage_index < 0 or stage_index >= len(stages):
+            raise IndexError("Stage index out of range")
+        return stages[stage_index].stage_beats
 
     # ---- MAP AND CHARACTER METHODS ----
     

--- a/backend/simulated/versioning/layer.py
+++ b/backend/simulated/versioning/layer.py
@@ -3,6 +3,7 @@ from simulated.components.map import SimulatedMap
 from simulated.components.characters import SimulatedCharacters
 from simulated.components.game_session import SimulatedGameSession
 from simulated.components.relationships import SimulatedRelationships
+from simulated.components.narrative import SimulatedNarrative
 if TYPE_CHECKING:
     from simulated.versioning.manager import GameStateVersionManager
     from simulated.game_state import SimulatedGameState
@@ -20,6 +21,7 @@ class SimulationLayer:
         self._characters: Optional[SimulatedCharacters] = None
         self._relationships: Optional[SimulatedRelationships] = None
         self._session: Optional[SimulatedGameSession] = None
+        self._narrative: Optional[SimulatedNarrative] = None
 
     @property
     def map(self) -> SimulatedMap:
@@ -56,6 +58,15 @@ class SimulationLayer:
             return self.parent.relationships
         else:
             return self._version_manager.base_relationships
+
+    @property
+    def narrative(self) -> SimulatedNarrative:
+        if self._narrative:
+            return self._narrative
+        elif self.parent:
+            return self.parent.narrative
+        else:
+            return self._version_manager.base_narrative
         
     def modify_map(self) -> SimulatedMap:
         if self._map is None:
@@ -76,6 +87,11 @@ class SimulationLayer:
         if self._relationships is None:
             self._relationships = deepcopy(self.relationships)
         return self._relationships
+
+    def modify_narrative(self) -> SimulatedNarrative:
+        if self._narrative is None:
+            self._narrative = deepcopy(self.narrative)
+        return self._narrative
     
     def has_modified_map(self) -> bool:
         return self._map is not None
@@ -95,6 +111,9 @@ class SimulationLayer:
     def has_modified_relationships(self) -> bool:
         return self._relationships is not None
 
+    def has_modified_narrative(self) -> bool:
+        return self._narrative is not None
+
     def get_modified_characters(self) -> SimulatedCharacters:
         return self._characters or self.characters
 
@@ -104,6 +123,9 @@ class SimulationLayer:
     def get_modified_relationships(self) -> SimulatedRelationships:
         return self._relationships or self.relationships
 
+    def get_modified_narrative(self) -> SimulatedNarrative:
+        return self._narrative or self.narrative
+
     def set_modified_characters(self, new_characters: SimulatedCharacters):
         self._characters = new_characters
 
@@ -112,3 +134,6 @@ class SimulationLayer:
 
     def set_modified_relationships(self, new_relationships: SimulatedRelationships):
         self._relationships = new_relationships
+
+    def set_modified_narrative(self, new_narrative: SimulatedNarrative):
+        self._narrative = new_narrative

--- a/backend/subsystems/agents/__init__.py
+++ b/backend/subsystems/agents/__init__.py
@@ -1,0 +1,11 @@
+from .narrative_handler import get_narrative_graph_app
+from .map_handler import get_map_graph_app
+from .character_handler import get_character_graph_app
+from .relationship_handler import get_relationship_graph_app
+
+__all__ = [
+    "get_narrative_graph_app",
+    "get_map_graph_app",
+    "get_character_graph_app",
+    "get_relationship_graph_app",
+]

--- a/backend/subsystems/agents/map_handler/__init__.py
+++ b/backend/subsystems/agents/map_handler/__init__.py
@@ -1,0 +1,5 @@
+"""Map management agent."""
+
+from .orchestrator import get_map_graph_app
+
+__all__ = ["get_map_graph_app"]

--- a/backend/subsystems/agents/narrative_handler/__init__.py
+++ b/backend/subsystems/agents/narrative_handler/__init__.py
@@ -1,0 +1,4 @@
+"""Narrative management agent."""
+from .orchestrator import get_narrative_graph_app
+
+__all__ = ["get_narrative_graph_app"]

--- a/backend/subsystems/agents/narrative_handler/nodes.py
+++ b/backend/subsystems/agents/narrative_handler/nodes.py
@@ -1,0 +1,135 @@
+from dotenv import load_dotenv
+load_dotenv()
+
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import ToolNode
+from typing import Sequence
+from .schemas.graph_state import NarrativeGraphState
+from .tools.narrative_tools import EXECUTORTOOLS, VALIDATIONTOOLS, finalize_simulation, validate_simulated_narrative
+from .prompts.reasoning import format_narrative_react_reason_prompt
+from .prompts.validating import format_narrative_react_validation_prompt
+from utils.message_window import get_valid_messages_window
+from langchain_core.messages import BaseMessage, HumanMessage, RemoveMessage
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+from simulated.singleton import SimulatedGameStateSingleton
+from subsystems.agents.utils.logs import ToolLog
+
+
+def receive_objective_node(state: NarrativeGraphState):
+    print("---ENTERING: RECEIVE OBJECTIVE NODE---")
+    SimulatedGameStateSingleton.begin_transaction()
+    initial_summary = (
+        SimulatedGameStateSingleton.get_instance().get_initial_narrative_summary()
+    )
+    return {
+        "narrative_current_try": 0,
+        "messages_field_to_update": "narrative_executor_messages",
+        "logs_field_to_update": "narrative_executor_applied_operations_log",
+        "narrative_current_executor_iteration": 0,
+        "narrative_initial_summary": initial_summary,
+        "narrative_executor_messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES)],
+        "narrative_task_finalized_by_agent": False,
+        "narrative_task_finalized_justification": None,
+        "narrative_current_validation_iteration": 0,
+        "narrative_task_succeeded_final": False,
+    }
+
+
+def narrative_executor_reason_node(state: NarrativeGraphState):
+    print("---ENTERING: REASON EXECUTION NODE---")
+    llm = ChatOpenAI(model="gpt-4.1-mini").bind_tools(EXECUTORTOOLS, tool_choice="any")
+    full_prompt = format_narrative_react_reason_prompt(
+        foundational_lore_document=state.narrative_foundational_lore_document,
+        recent_operations_summary=state.narrative_recent_operations_summary,
+        relevant_entity_details=state.narrative_relevant_entity_details,
+        additional_information=state.narrative_additional_information,
+        rules_and_constraints=state.narrative_rules_and_constraints,
+        initial_summary=state.narrative_initial_summary,
+        objective=state.narrative_current_objective,
+        other_guidelines=state.narrative_other_guidelines,
+        messages=get_valid_messages_window(state.narrative_executor_messages, 30),
+    )
+    state.narrative_current_executor_iteration += 1
+    response = llm.invoke(full_prompt)
+    return {
+        "narrative_executor_messages": [response],
+        "narrative_current_executor_iteration": state.narrative_current_executor_iteration,
+    }
+
+narrative_executor_tool_node = ToolNode(EXECUTORTOOLS)
+narrative_executor_tool_node.messages_key = "narrative_executor_messages"
+
+
+def receive_result_for_validation_node(state: NarrativeGraphState):
+    print("---ENTERING: RECEIVE RESULT FOR VALIDATION NODE---")
+
+    def format_relevant_logs(operation_logs: Sequence[ToolLog]) -> str:
+        final_str = ""
+        for operation in operation_logs:
+            if operation.success and not operation.is_query:
+                final_str += f"Result of '{operation.tool_called}': {operation.message}\n"
+        return final_str
+
+    return {
+        "narrative_validation_messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES)],
+        "messages_field_to_update": "narrative_validation_messages",
+        "narrative_executor_agent_relevant_logs": format_relevant_logs(state.narrative_executor_applied_operations_log),
+        "logs_field_to_update": "narrative_validator_applied_operations_log",
+        "narrative_agent_validated": False,
+        "narrative_agent_validation_conclusion_flag": False,
+        "narrative_agent_validation_assessment_reasoning": "",
+        "narrative_agent_validation_suggested_improvements": "",
+        "narrative_current_validation_iteration": 0,
+    }
+
+
+def narrative_validation_reason_node(state: NarrativeGraphState):
+    print("---ENTERING: REASON VALIDATION NODE---")
+    state.narrative_current_validation_iteration += 1
+    validation_llm = ChatOpenAI(model="gpt-4.1-mini").bind_tools(VALIDATIONTOOLS, tool_choice="any")
+    full_prompt = format_narrative_react_validation_prompt(
+        state.narrative_current_objective,
+        state.narrative_executor_agent_relevant_logs,
+        state.narrative_validation_messages,
+    )
+    response = validation_llm.invoke(full_prompt)
+    return {
+        "narrative_validation_messages": [response],
+        "narrative_current_validation_iteration": state.narrative_current_validation_iteration,
+    }
+
+narrative_validation_tool_node = ToolNode(VALIDATIONTOOLS)
+narrative_validation_tool_node.messages_key = "narrative_validation_messages"
+
+
+def retry_executor_node(state: NarrativeGraphState):
+    print("---ENTERING: RETRY NODE---")
+    feedback = (
+        "Here's some human feedback on how you have done so far on your task:\n"
+        f"You have still not completed your task\n Reason: {state.narrative_agent_validation_assessment_reasoning}\n"
+        f"Suggestion/s:{state.narrative_agent_validation_suggested_improvements} "
+    )
+    feedback_message = HumanMessage(feedback)
+    return {
+        "narrative_executor_messages": [feedback_message],
+        "messages_field_to_update": "narrative_executor_messages",
+        "logs_field_to_update": "narrative_executor_applied_operations_log",
+        "narrative_current_executor_iteration": 0,
+        "narrative_current_try": state.narrative_current_try + 1,
+    }
+
+
+def final_node_success(state: NarrativeGraphState):
+    print("---ENTERING: LAST NODE OBJECTIVE SUCCESS---")
+    SimulatedGameStateSingleton.commit()
+    return {
+        "narrative_task_succeeded_final": True,
+    }
+
+
+def final_node_failure(state: NarrativeGraphState):
+    print("---ENTERING: LAST NODE OBJECTIVE FAILED---")
+    SimulatedGameStateSingleton.rollback()
+    return {
+        "narrative_task_succeeded_final": False,
+    }

--- a/backend/subsystems/agents/narrative_handler/orchestrator.py
+++ b/backend/subsystems/agents/narrative_handler/orchestrator.py
@@ -1,0 +1,77 @@
+from langgraph.graph import StateGraph, END, START
+from subsystems.agents.narrative_handler.schemas.graph_state import NarrativeGraphState
+from subsystems.agents.narrative_handler.nodes import *
+from langchain_core.messages import ToolMessage
+
+
+def iteration_limit_exceeded_or_agent_finalized(state: NarrativeGraphState) -> str:
+    current_iteration = state.narrative_current_executor_iteration
+    max_iterations = state.narrative_max_executor_iterations
+    if state.narrative_task_finalized_by_agent or current_iteration >= max_iterations:
+        if state.narrative_max_validation_iterations > 0:
+            return "finalize_executor_and_validate"
+        else:
+            return "finalize_executor_and_succeed"
+    else:
+        return "continue_executor"
+
+
+def iteration_limit_exceeded_or_agent_validated(state: NarrativeGraphState) -> str:
+    current_iteration = state.narrative_current_validation_iteration
+    tries_to_evaluate_after_max_iterations = 3
+    max_iterations = state.narrative_max_validation_iterations + tries_to_evaluate_after_max_iterations
+    if state.narrative_agent_validated or current_iteration >= max_iterations:
+        if state.narrative_agent_validation_conclusion_flag:
+            return "finalize_success"
+        else:
+            if state.narrative_current_try <= state.narrative_max_retries:
+                return "retry_executor"
+            else:
+                return "finalize_failure"
+    else:
+        return "continue_validation"
+
+
+def get_narrative_graph_app():
+    workflow = StateGraph(NarrativeGraphState)
+
+    workflow.add_node("executor_receive_objective", receive_objective_node)
+    workflow.add_node("executor_reason", narrative_executor_reason_node)
+    workflow.add_node("executor_tool", narrative_executor_tool_node)
+    workflow.add_node("validation_receive_result", receive_result_for_validation_node)
+    workflow.add_node("validation_reason", narrative_validation_reason_node)
+    workflow.add_node("validation_tool", narrative_validation_tool_node)
+    workflow.add_node("retry_executor", retry_executor_node)
+    workflow.add_node("final_node_success", final_node_success)
+    workflow.add_node("final_node_failure", final_node_failure)
+
+    workflow.add_edge(START, "executor_receive_objective")
+    workflow.add_edge("executor_receive_objective", "executor_reason")
+    workflow.add_edge("executor_reason", "executor_tool")
+    workflow.add_conditional_edges(
+        "executor_tool",
+        iteration_limit_exceeded_or_agent_finalized,
+        {
+            "continue_executor": "executor_reason",
+            "finalize_executor_and_validate": "validation_receive_result",
+            "finalize_executor_and_succeed": "final_node_success",
+        },
+    )
+    workflow.add_edge("validation_receive_result", "validation_reason")
+    workflow.add_edge("validation_reason", "validation_tool")
+    workflow.add_conditional_edges(
+        "validation_tool",
+        iteration_limit_exceeded_or_agent_validated,
+        {
+            "continue_validation": "validation_reason",
+            "finalize_success": "final_node_success",
+            "finalize_failure": "final_node_failure",
+            "retry_executor": "retry_executor",
+        },
+    )
+    workflow.add_edge("retry_executor", "executor_reason")
+    workflow.add_edge("final_node_success", END)
+    workflow.add_edge("final_node_failure", END)
+
+    app = workflow.compile()
+    return app

--- a/backend/subsystems/agents/narrative_handler/prompts/__init__.py
+++ b/backend/subsystems/agents/narrative_handler/prompts/__init__.py
@@ -1,0 +1,7 @@
+from .reasoning import format_narrative_react_reason_prompt
+from .validating import format_narrative_react_validation_prompt
+
+__all__ = [
+    "format_narrative_react_reason_prompt",
+    "format_narrative_react_validation_prompt",
+]

--- a/backend/subsystems/agents/narrative_handler/prompts/reasoning.py
+++ b/backend/subsystems/agents/narrative_handler/prompts/reasoning.py
@@ -1,0 +1,103 @@
+from typing import List, Sequence
+from langchain_core.prompts import ChatPromptTemplate
+from langchain.prompts import SystemMessagePromptTemplate, HumanMessagePromptTemplate, MessagesPlaceholder
+from langchain_core.messages import BaseMessage
+
+SYSTEM_PROMPT = """
+You are 'NarrativeEngineAI', a specialized AI integrated into a **video game's development and simulation pipeline**. Your purpose is to manage the game's narrative beats step-by-step, by directly manipulating the **game's state** through a set of provided tools.
+
+**Your Role in the Game Ecosystem:**
+* You are not just a creative writer; you are a **system operator**.
+* Your tool calls are **API requests** that modify a live, persistent database (the `GameState`).
+* The final narrative data you create and modify will drive the unfolding story for players.
+* You work alongside other AI agents that may be managing maps, characters, relationships, etc. **Your actions must be coherent with the overall game state.**
+
+**Your Primary Objective:**
+Interpret the user's high-level objective and execute a logical sequence of **API calls (using your available tools)** to modify the narrative until the objective is fully met. Pay close attention to any numerical targets or structural constraints, as meeting these is a primary condition for completion.
+
+**Available Tools:**
+You have access to a set of tools. Each comes with a detailed description and a schema for its expected arguments. Use these tools exactly as defined. **Do not invent new tools or use any that are not listed.** Pay close attention to the required arguments for each tool.
+
+**Your Work Process (ReAct Loop):**
+1. **REASON:** Carefully analyze the objective, the provided game context, the current narrative data (based on previous tool observations), and any feedback. Decide on the *next most logical action/s* to move toward the objective.
+2. **ACT:** Choose the appropriate tool or tools and call them using the correct arguments as defined in its schema.
+   - If you need more information about the current state of the narrative to make an informed decision, USE QUERY TOOLS.
+   - If you have sufficient information, select the appropriate MODIFICATION tool or tools and apply them.
+3. **OBSERVE:** You will receive a result from each tool call. This result will indicate whether the operation succeeded and provide an updated summary of the simulated narrative state. Use this information in your next reasoning step.
+4. **REPEAT:** Continue this Reason-Act-Observe cycle until you are confident that the `objective` has been fully satisfied.
+
+**Task Completion:**
+Once you are convinced that the simulated narrative fulfills the `objective` and is coherent:
+- You must call the `finalize_simulation` tool.
+- This tool requires a `justification` explaining why the **final narrative state is correct and complete** according to the objective.
+- This **MUST BE YOUR FINAL ACTION**. Do not call any other tools afterward.
+
+**Error Handling:**
+If a tool returns an error, analyze the error message in your OBSERVE step. In your next REASONING step, decide how to fix the issue: you may retry the tool with different arguments, try an alternative tool, or reconsider part of your strategy.
+"""
+
+HUMAN_PROMPT = """
+Below is all the information you need to complete your objective. Act accordingly.
+
+## 1. The World Context
+{foundational_lore_document}
+
+### Recent Operations Summary
+{recent_operations_summary}
+
+### Relevant Entity Information
+{relevant_entity_details}
+
+### Additional Information (Optional)
+{additional_information}
+
+## 2. Supporting Information & Constraints
+### Rules and Constraints (Mandatory):
+{rules_and_constraints}
+
+### Other Guidelines (Softer rules):
+{other_guidelines}
+
+### Initial Narrative State Summary (if applicable):
+{initial_summary}
+
+## 3. Your Primary Objective
+**{objective}**
+
+Begin your reasoning process now.
+"""
+
+SYSTEM_PROMPT_TEMPLATE = SystemMessagePromptTemplate.from_template(SYSTEM_PROMPT)
+HUMAN_PROMPT_TEMPLATE = HumanMessagePromptTemplate.from_template(HUMAN_PROMPT)
+
+chat_prompt_template = ChatPromptTemplate([
+    SYSTEM_PROMPT_TEMPLATE,
+    HUMAN_PROMPT_TEMPLATE,
+    MessagesPlaceholder(variable_name="agent_scratchpad"),
+])
+
+def format_narrative_react_reason_prompt(
+    foundational_lore_document: str,
+    recent_operations_summary: str,
+    relevant_entity_details: str,
+    additional_information: str,
+    rules_and_constraints: List[str],
+    initial_summary: str,
+    objective: str,
+    other_guidelines: str,
+    messages: Sequence[BaseMessage],
+) -> List[BaseMessage]:
+    prompt_input_values = {
+        "foundational_lore_document": foundational_lore_document,
+        "recent_operations_summary": recent_operations_summary,
+        "relevant_entity_details": relevant_entity_details,
+        "additional_information": additional_information,
+        "rules_and_constraints": "; ".join(rules_and_constraints),
+        "initial_summary": initial_summary,
+        "objective": objective,
+        "other_guidelines": other_guidelines,
+        "agent_scratchpad": messages,
+    }
+
+    formatted_messages = chat_prompt_template.format_messages(**prompt_input_values)
+    return formatted_messages

--- a/backend/subsystems/agents/narrative_handler/prompts/validating.py
+++ b/backend/subsystems/agents/narrative_handler/prompts/validating.py
@@ -1,0 +1,71 @@
+from typing import List, Sequence
+from langchain_core.prompts import ChatPromptTemplate
+from langchain.prompts import SystemMessagePromptTemplate, HumanMessagePromptTemplate, MessagesPlaceholder
+from langchain_core.messages import BaseMessage
+
+REACT_VALIDATOR_SYSTEM_PROMPT_TEMPLATE_STRING = """
+## ROLE ##
+You are a VideoGame Narrative Validation Agent. Your specialty is to meticulously analyze the conformity of a simulated narrative against a set of design objectives. You are logical, detail-oriented, and your reasoning is strictly based on the evidence provided.
+
+## Your Primary Objective ##
+Your primary mission is to **determine if the simulated narrative MEETS or DOES NOT MEET the `narrative_objective`**.
+
+## INPUT (Inputs You Will Receive) ##
+For each validation task, you will receive the following information:
+
+1. **`narrative_objective`**: A description of the rules, constraints and requirements the narrative was supposed to fulfill.
+2. **`constructor_agent_logs`**: A sequential record of actions and observation results from the agent that created or modified the narrative. These logs will allow you to understand the constructor agent's decision-making process.
+
+## Available Tools ##
+You have access to a set of tools. Each comes with a detailed description and a schema for its expected arguments. Use these tools exactly as defined. **Do not invent new tools or use any that are not listed.**
+
+## Your Work Process (ReAct Loop): ##
+1. **REASON:** Carefully analyze the objective, all provided context, the current state of the final simulated narrative (based on previous tool observations). Decide on the *next most logical action/s* to move toward the objective.
+2. **ACT:** Choose the appropriate tool/tools and call them using the correct arguments as defined in its schema.
+   - If you need more information about the current state of the narrative to make an informed decision, USE QUERY TOOLS.
+   - If you have sufficient information, select the validate tool to give a final validation.
+3. **OBSERVE:** You will receive a result from the tool. Use this information in your next reasoning step.
+4. **REPEAT:** Continue this Reason-Act-Observe cycle until you are confident that you can give a validation.
+
+## Task Completion ##
+Once you are convinced and have enough information to know whether the narrative MEETS or DOES NOT MEET the `narrative_objective`:
+- You must call the `validate_simulated_narrative` tool.
+- This tool requires a flag indicating if the narrative meets the objective or not, the reasoning behind this evaluation, and an argument to provide suggested improvements if the narrative did not satisfy the objective.
+- This **MUST BE YOUR FINAL ACTION**. Do not call any other tools afterward.
+"""
+
+REACT_VALIDATOR_HUMAN_PROMPT_TEMPLATE_STRING = """
+**1. Narrative Objective (`narrative_objective`):**
+{narrative_objective}
+**2. Constructor Agent Logs (`constructor_agent_logs`):**
+{constructor_agent_logs}
+"""
+
+REACT_VALIDATOR_SYSTEM_PROMPT_TEMPLATE = SystemMessagePromptTemplate.from_template(
+    REACT_VALIDATOR_SYSTEM_PROMPT_TEMPLATE_STRING
+)
+
+REACT_VALIDATOR_HUMAN_PROMPT_TEMPLATE = HumanMessagePromptTemplate.from_template(
+    REACT_VALIDATOR_HUMAN_PROMPT_TEMPLATE_STRING
+)
+
+chat_prompt_template = ChatPromptTemplate([
+    REACT_VALIDATOR_SYSTEM_PROMPT_TEMPLATE,
+    REACT_VALIDATOR_HUMAN_PROMPT_TEMPLATE,
+    MessagesPlaceholder(variable_name="agent_scratchpad"),
+])
+
+def format_narrative_react_validation_prompt(
+    narrative_objective: str,
+    constructor_agent_logs: str,
+    validating_messages: Sequence[BaseMessage],
+) -> List[BaseMessage]:
+    prompt_input_values = {
+        "narrative_objective": narrative_objective,
+        "constructor_agent_logs": constructor_agent_logs,
+        "agent_scratchpad": validating_messages,
+    }
+
+    formatted_messages = chat_prompt_template.format_messages(**prompt_input_values)
+    return formatted_messages
+

--- a/backend/subsystems/agents/narrative_handler/schemas/__init__.py
+++ b/backend/subsystems/agents/narrative_handler/schemas/__init__.py
@@ -1,0 +1,3 @@
+from .graph_state import NarrativeGraphState
+
+__all__ = ["NarrativeGraphState"]

--- a/backend/subsystems/agents/narrative_handler/schemas/graph_state.py
+++ b/backend/subsystems/agents/narrative_handler/schemas/graph_state.py
@@ -1,0 +1,43 @@
+from typing import List, Optional, Sequence, Annotated
+from pydantic import BaseModel, Field
+from langgraph.graph.message import add_messages
+from langchain_core.messages import BaseMessage
+from subsystems.agents.utils.schemas import ToolLog
+from subsystems.agents.utils.logs import log_reducer
+
+class NarrativeGraphState(BaseModel):
+    """Holds context and working memory for the narrative agent."""
+    narrative_foundational_lore_document: str = Field(default="", alias="narrative_global_narrative_context")
+    narrative_recent_operations_summary: str = Field(default="")
+    narrative_relevant_entity_details: str = Field(default="")
+    narrative_additional_information: str = Field(default="")
+
+    narrative_rules_and_constraints: List[str] = Field(default_factory=list)
+    narrative_current_objective: str = Field(default="")
+    narrative_other_guidelines: str = Field(default="")
+    narrative_initial_summary: str = Field(default="")
+
+    narrative_max_retries: int = Field(default=1)
+    narrative_current_try: int = Field(default=1)
+
+    narrative_executor_messages: Annotated[Sequence[BaseMessage], add_messages] = Field(default_factory=list)
+    narrative_current_executor_iteration: int = Field(default=0)
+    narrative_max_executor_iterations: int = Field(default=6)
+    narrative_task_finalized_by_agent: bool = Field(default=False)
+    narrative_task_finalized_justification: Optional[str] = Field(default=None)
+    narrative_executor_applied_operations_log: Annotated[Sequence[ToolLog], log_reducer] = Field(default_factory=list)
+
+    narrative_max_validation_iterations: int = Field(default=3)
+    narrative_current_validation_iteration: int = Field(default=0)
+    narrative_executor_agent_relevant_logs: str = Field(default="")
+    narrative_validation_messages: Annotated[Sequence[BaseMessage], add_messages] = Field(default_factory=list)
+    narrative_agent_validation_conclusion_flag: bool = Field(default=False)
+    narrative_agent_validation_assessment_reasoning: str = Field(default="")
+    narrative_agent_validation_suggested_improvements: str = Field(default="")
+    narrative_agent_validated: bool = Field(default=False)
+    narrative_validator_applied_operations_log: Annotated[Sequence[ToolLog], log_reducer] = Field(default_factory=list)
+
+    narrative_task_succeeded_final: bool = Field(default=False)
+
+    logs_field_to_update: str = Field(default="logs")
+    messages_field_to_update: str = Field(default="messages")

--- a/backend/subsystems/agents/narrative_handler/tools/__init__.py
+++ b/backend/subsystems/agents/narrative_handler/tools/__init__.py
@@ -1,0 +1,13 @@
+from .narrative_tools import (
+    EXECUTORTOOLS,
+    VALIDATIONTOOLS,
+    finalize_simulation,
+    validate_simulated_narrative,
+)
+
+__all__ = [
+    "EXECUTORTOOLS",
+    "VALIDATIONTOOLS",
+    "finalize_simulation",
+    "validate_simulated_narrative",
+]

--- a/backend/subsystems/agents/narrative_handler/tools/narrative_tools.py
+++ b/backend/subsystems/agents/narrative_handler/tools/narrative_tools.py
@@ -1,0 +1,157 @@
+from typing import Annotated
+from pydantic import BaseModel, Field
+from langchain_core.tools import tool, InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+from simulated.singleton import SimulatedGameStateSingleton
+from subsystems.agents.utils.schemas import InjectedToolContext
+from subsystems.agents.utils.logs import get_log_item, extract_tool_args
+from core_game.narrative.schemas import (
+    NarrativeBeatModel,
+    FailureConditionModel,
+    RiskTriggeredBeats,
+)
+
+class ToolAddNarrativeBeatArgs(InjectedToolContext):
+    stage_index: int = Field(..., description="Stage index to add the beat")
+    beat_id: str = Field(..., description="Unique id for the beat")
+    description: str = Field(..., description="Description of the beat")
+    priority: int = Field(10, description="Beat priority")
+
+class ToolCreateFailureConditionArgs(InjectedToolContext):
+    condition_id: str = Field(..., description="Failure condition id")
+    description: str = Field(..., description="Description")
+
+class ToolAddRiskTriggeredBeatArgs(InjectedToolContext):
+    condition_id: str = Field(..., description="Failure condition id")
+    trigger_risk_level: int = Field(..., ge=0, le=100)
+    deactivate_risk_level: int = Field(..., ge=0, le=100)
+    beat_id: str = Field(..., description="Beat id")
+    description: str = Field(..., description="Beat description")
+    priority: int = Field(10)
+
+class ToolSetFailureRiskLevelArgs(InjectedToolContext):
+    condition_id: str = Field(...)
+    risk_level: int = Field(..., ge=0, le=100)
+
+class ToolFinalizeSimulationArgs(InjectedToolContext):
+    justification: str
+
+class ToolValidateSimulatedNarrativeArgs(InjectedToolContext):
+    does_narrative_meet_criteria: bool
+    assessment_reasoning: str
+    suggested_improvements: str | None = None
+
+@tool(args_schema=ToolAddNarrativeBeatArgs)
+def add_narrative_beat(stage_index: int, beat_id: str, description: str, priority: int,
+                       messages_field_to_update: Annotated[str, InjectedState("messages_field_to_update")],
+                       logs_field_to_update: Annotated[str, InjectedState("logs_field_to_update")],
+                       tool_call_id: Annotated[str, InjectedToolCallId]) -> Command:
+    """Add a narrative beat to a stage."""
+    args = extract_tool_args(locals())
+    beat = NarrativeBeatModel(id=beat_id, description=description, priority=priority)
+    SimulatedGameStateSingleton.get_instance().add_narrative_beat(stage_index, beat)
+    message = f"Beat '{beat_id}' added"
+    return Command(update={
+        logs_field_to_update: [get_log_item("add_narrative_beat", args, False, True, message)],
+        messages_field_to_update: [ToolMessage(message, tool_call_id=tool_call_id)],
+    })
+
+@tool(args_schema=ToolCreateFailureConditionArgs)
+def create_failure_condition(condition_id: str, description: str,
+                             messages_field_to_update: Annotated[str, InjectedState("messages_field_to_update")],
+                             logs_field_to_update: Annotated[str, InjectedState("logs_field_to_update")],
+                             tool_call_id: Annotated[str, InjectedToolCallId]) -> Command:
+    """Create a new failure condition."""
+    args = extract_tool_args(locals())
+    fc = FailureConditionModel(id=condition_id, description=description)
+    SimulatedGameStateSingleton.get_instance().add_failure_condition(fc)
+    message = f"Failure condition '{condition_id}' created"
+    return Command(update={
+        logs_field_to_update: [get_log_item("create_failure_condition", args, False, True, message)],
+        messages_field_to_update: [ToolMessage(message, tool_call_id=tool_call_id)],
+    })
+
+@tool(args_schema=ToolAddRiskTriggeredBeatArgs)
+def add_risk_triggered_beat(condition_id: str, trigger_risk_level: int, deactivate_risk_level: int,
+                            beat_id: str, description: str, priority: int,
+                            messages_field_to_update: Annotated[str, InjectedState("messages_field_to_update")],
+                            logs_field_to_update: Annotated[str, InjectedState("logs_field_to_update")],
+                            tool_call_id: Annotated[str, InjectedToolCallId]) -> Command:
+    """Associate beats to a failure condition triggered at certain risk level."""
+    args = extract_tool_args(locals())
+    beat = NarrativeBeatModel(id=beat_id, description=description, priority=priority, origin="FAILURE_CONDITION")
+    rtb = RiskTriggeredBeats(trigger_risk_level=trigger_risk_level, deactivate_risk_level=deactivate_risk_level, beats=[beat])
+    SimulatedGameStateSingleton.get_instance().add_risk_triggered_beats(condition_id, rtb)
+    message = f"Risk triggered beat '{beat_id}' added"
+    return Command(update={
+        logs_field_to_update: [get_log_item("add_risk_triggered_beat", args, False, True, message)],
+        messages_field_to_update: [ToolMessage(message, tool_call_id=tool_call_id)],
+    })
+
+@tool(args_schema=ToolSetFailureRiskLevelArgs)
+def set_failure_risk_level(condition_id: str, risk_level: int,
+                           messages_field_to_update: Annotated[str, InjectedState("messages_field_to_update")],
+                           logs_field_to_update: Annotated[str, InjectedState("logs_field_to_update")],
+                           tool_call_id: Annotated[str, InjectedToolCallId]) -> Command:
+    """Set the risk level of a failure condition."""
+    args = extract_tool_args(locals())
+    SimulatedGameStateSingleton.get_instance().set_failure_risk_level(condition_id, risk_level)
+    message = f"Risk level for '{condition_id}' set to {risk_level}"
+    return Command(update={
+        logs_field_to_update: [get_log_item("set_failure_risk_level", args, False, True, message)],
+        messages_field_to_update: [ToolMessage(message, tool_call_id=tool_call_id)],
+    })
+
+@tool(args_schema=ToolFinalizeSimulationArgs)
+def finalize_simulation(justification: str,
+                        messages_field_to_update: Annotated[str, InjectedState("messages_field_to_update")],
+                        logs_field_to_update: Annotated[str, InjectedState("logs_field_to_update")],
+                        tool_call_id: Annotated[str, InjectedToolCallId]) -> Command:
+    """Finalize the narrative executor."""
+    args = extract_tool_args(locals())
+    message = justification
+    return Command(update={
+        logs_field_to_update: [get_log_item("finalize_simulation", args, False, True, message)],
+        messages_field_to_update: [ToolMessage(message, tool_call_id=tool_call_id)],
+        "narrative_task_finalized_by_agent": True,
+        "narrative_task_finalized_justification": justification,
+    })
+
+@tool(args_schema=ToolValidateSimulatedNarrativeArgs)
+def validate_simulated_narrative(messages_field_to_update: Annotated[str, InjectedState("messages_field_to_update")],
+                                 logs_field_to_update: Annotated[str, InjectedState("logs_field_to_update")],
+                                 tool_call_id: Annotated[str, InjectedToolCallId],
+                                 does_narrative_meet_criteria: bool,
+                                 assessment_reasoning: str,
+                                 suggested_improvements: str | None = None) -> Command:
+    """Validate the narrative after execution."""
+    args = extract_tool_args(locals())
+    if not suggested_improvements:
+        suggested_improvements = ""
+    if does_narrative_meet_criteria:
+        message = f"Narrative meets criteria. Reason: {assessment_reasoning}"
+    else:
+        message = f"Narrative does not meet criteria. Reason: {assessment_reasoning}. Suggestions: {suggested_improvements}"
+    return Command(update={
+        logs_field_to_update: [get_log_item("validate_simulated_narrative", args, False, True, message)],
+        messages_field_to_update: [ToolMessage(message, tool_call_id=tool_call_id)],
+        "narrative_agent_validated": True,
+        "narrative_agent_validation_conclusion_flag": does_narrative_meet_criteria,
+        "narrative_agent_validation_assessment_reasoning": assessment_reasoning,
+        "narrative_agent_validation_suggested_improvements": suggested_improvements,
+    })
+
+EXECUTORTOOLS = [
+    add_narrative_beat,
+    create_failure_condition,
+    add_risk_triggered_beat,
+    set_failure_risk_level,
+    finalize_simulation,
+]
+
+VALIDATIONTOOLS = [
+    validate_simulated_narrative,
+]


### PR DESCRIPTION
## Summary
- implement `get_initial_summary` in NarrativeState
- expose summary via SimulatedNarrative and SimulatedGameState
- include initial narrative summary when receiving objectives

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863a78badcc832ea62fc96a880624c6