### PR TITLE
Implement main goal in narrative component

### DIFF
--- a/backend/core_game/game_session/domain.py
+++ b/backend/core_game/game_session/domain.py
@@ -18,8 +18,7 @@ class GameSession:
         self._user_prompt: Optional[str]
         self._refined_prompt: Optional[str]
         self._time: GameTime 
-        self._global_flags: Dict[str, Any] 
-        self._player_main_goal: Optional[str]
+        self._global_flags: Dict[str, Any]
         if model:
             self._populate_from_model(model)
         else:
@@ -28,7 +27,6 @@ class GameSession:
             self._refined_prompt = None
             self._time = GameTime()
             self._global_flags = {}
-            self._player_main_goal = None
     
 
     def _populate_from_model(self, model: GameSessionModel) -> None:
@@ -38,7 +36,6 @@ class GameSession:
         self._refined_prompt = model.refined_prompt
         self._time = GameTime(model.narrative_time)
         self._global_flags = model.global_flags
-        self._player_main_goal = model.player_main_goal
 
     # ------------------------------------------------------------------
     # Accessor properties
@@ -64,9 +61,6 @@ class GameSession:
     def global_flags(self) -> Dict[str, Any]:
         return self._global_flags
 
-    @property
-    def player_main_goal(self) -> Optional[str]:
-        return self._player_main_goal
 
     # ------------------------------------------------------------------
     # Modification methods
@@ -80,9 +74,6 @@ class GameSession:
         """Update the refined user prompt."""
         self._refined_prompt = prompt
 
-    def set_player_main_goal(self, goal: str) -> None:
-        """Set the player's main goal for the session."""
-        self._player_main_goal = goal
 
     def set_global_flag(self, key: str, value: Any) -> None:
         """Set or update a global flag."""

--- a/backend/core_game/game_session/schemas.py
+++ b/backend/core_game/game_session/schemas.py
@@ -21,6 +21,5 @@ class GameSessionModel(BaseModel):
     session_id: str = Field(..., description="Unique identifier for the game session.")
     user_prompt: str = Field(..., description="The initial prompt that generated this world.")
     refined_prompt: str = Field(..., description="The refined user prompt")
-    player_main_goal: str = Field(..., description="The main goal for the player in the narrative")
     narrative_time: GameTimeModel = Field(..., description="The current state of in-game time.")
     global_flags: Dict[str, Any] = Field(default_factory=dict, description="Dictionary for global world state flags (e.g., 'current_weather': 'storm', 'city_on_lockdown': True / False, ).")

--- a/backend/core_game/narrative/domain.py
+++ b/backend/core_game/narrative/domain.py
@@ -8,6 +8,7 @@ from core_game.narrative.schemas import (
     NarrativeStageModel,
     NarrativeStructureModel,
     NarrativeStructureTypeModel,
+    GoalModel,
 )
 from core_game.narrative.structures import AVAILABLE_NARRATIVE_STRUCTURES
 
@@ -42,6 +43,19 @@ class NarrativeState:
     @property
     def failure_conditions(self) -> list[FailureConditionModel]:
         return self._data.failure_conditions
+
+    # ------------------------------------------------------------------
+    # Main goal helpers
+    # ------------------------------------------------------------------
+    def set_main_goal(self, goal: str) -> None:
+        """Define the main goal of the narrative."""
+        self._data.main_goal = GoalModel(description=goal)
+
+    def get_main_goal(self) -> Optional[str]:
+        """Return the main goal description if defined."""
+        if self._data.main_goal is None:
+            return None
+        return self._data.main_goal.description
 
     # ------------------------------------------------------------------
     # Configuration methods

--- a/backend/simulated/components/game_session.py
+++ b/backend/simulated/components/game_session.py
@@ -24,8 +24,6 @@ class SimulatedGameSession:
     def set_refined_prompt(self, prompt: str) -> None:
         self._working_state.set_refined_prompt(prompt)
 
-    def set_player_main_goal(self, goal: str) -> None:
-        self._working_state.set_player_main_goal(goal)
 
     def set_global_flag(self, key: str, value: Any) -> None:
         self._working_state.set_global_flag(key, value)
@@ -42,10 +40,6 @@ class SimulatedGameSession:
 
     def get_refined_prompt(self) -> Optional[str]:
         return self._working_state.refined_prompt
-
-
-    def get_player_main_goal(self) -> Optional[str]:
-        return self._working_state.player_main_goal
 
 
     def get_global_flags(self) -> dict[str, Any]:

--- a/backend/simulated/components/narrative.py
+++ b/backend/simulated/components/narrative.py
@@ -24,6 +24,13 @@ class SimulatedNarrative:
     def get_initial_summary(self) -> str:
         """Return summary info about the current narrative stage."""
         return self._working_state.get_initial_summary()
+
+    # ---- Main goal helpers ----
+    def set_main_goal(self, goal: str) -> None:
+        self._working_state.set_main_goal(goal)
+
+    def get_main_goal(self) -> str | None:
+        return self._working_state.get_main_goal()
     
     def set_narrative_structure(self, structure_type: NarrativeStructureTypeModel) -> None:
         self._working_state.set_narrative_structure(structure_type)

--- a/backend/simulated/game_state.py
+++ b/backend/simulated/game_state.py
@@ -184,8 +184,8 @@ class SimulatedGameState:
     def set_refined_prompt(self, prompt: str) -> None:
         self._write_session.set_refined_prompt(prompt)
 
-    def set_player_main_goal(self, goal: str) -> None:
-        self._write_session.set_player_main_goal(goal)
+    def set_main_goal(self, goal: str) -> None:
+        self._write_narrative.set_main_goal(goal)
 
     def set_global_flag(self, key: str, value: Any) -> None:
         self._write_session.set_global_flag(key, value)
@@ -202,8 +202,8 @@ class SimulatedGameState:
     def get_refined_prompt(self):
         return self._read_session.get_refined_prompt()
 
-    def get_player_main_goal(self):
-        return self._read_session.get_player_main_goal()
+    def get_main_goal(self):
+        return self._read_narrative.get_main_goal()
 
     def get_global_flags(self):
         return self._read_session.get_global_flags()

--- a/backend/subsystems/generation/nodes.py
+++ b/backend/subsystems/generation/nodes.py
@@ -14,7 +14,7 @@ def prepare_refinement(state: GenerationGraphState):
     refined_prompt = game_state.get_refined_prompt()
     assert refined_prompt is not None, "Refined prompt should not be None at prepare refinement"  
 
-    main_goal = game_state.get_player_main_goal()
+    main_goal = game_state.get_main_goal()
     assert main_goal is not None, "Player main goal should not be None at prepare refinement"
 
     foundational_info = refined_prompt + "\n In this narrative world, the player has the following goal/objective: " + main_goal

--- a/backend/subsystems/generation/seed/nodes.py
+++ b/backend/subsystems/generation/seed/nodes.py
@@ -203,7 +203,7 @@ def narrative_structure_reason_node(state: SeedGenerationGraphState):
 
     #save the main goal
     game_state = SimulatedGameStateSingleton.get_instance()
-    game_state.set_player_main_goal(state.main_goal)
+    game_state.set_main_goal(state.main_goal)
 
     print("---ENTERING: NARRATIVE STRUCTURE REASON NODE---")
 


### PR DESCRIPTION
## Summary
- manage the narrative main goal from `NarrativeState`
- drop player main goal tracking in `GameSession`
- expose setters/getters for the main goal through `SimulatedNarrative`
- route game state calls to these new narrative methods
- update generation nodes to use the new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863bf1ddd9c832ea22de8a192384ab9