### PR TITLE
Add beat details to structure query

### DIFF
--- a/backend/core_game/narrative/domain.py
+++ b/backend/core_game/narrative/domain.py
@@ -111,18 +111,63 @@ class NarrativeState:
     # Summary helpers
     # ------------------------------------------------------------------
     def get_initial_summary(self) -> str:
-        """Return the current stage and beats summary."""
+        """Return the main goal, stage list, and current stage beats."""
         if self._data.narrative_structure is None:
             return "No narrative structure selected"
-        stage_index = self._data.current_stage_index or 0
+
         stages = self._data.narrative_structure.stages
-        if stage_index < 0 or stage_index >= len(stages):
+        current_index = self._data.current_stage_index or 0
+        if current_index < 0 or current_index >= len(stages):
             return "No current narrative stage"
-        stage = stages[stage_index]
-        if stage.stage_beats:
-            beats_summary = ", ".join(
-                f"{b.id} [{b.status}]" for b in stage.stage_beats
+
+        goal_desc = self.get_main_goal()
+
+        lines = []
+        if goal_desc:
+            lines.append(f"Main goal for the player: {goal_desc}")
+
+        structure_name = self._data.narrative_structure.structure_type.name
+        lines.append(f"Narrative structure: {structure_name}")
+
+        for i, stage in enumerate(stages, start=1):
+            marker = " (current)" if (i - 1) == current_index else ""
+            lines.append(f"- Stage {i}: {stage.name}{marker}")
+            if stage.stage_beats:
+                beats = ", ".join(
+                    f"{beat.id} [{beat.status}]" for beat in stage.stage_beats
+                )
+            else:
+                beats = "No beats"
+            lines.append(f"  Beats: {beats}")
+
+        return "\n".join(lines)
+
+    def get_structure_details(self) -> str:
+        """Return all stage names, objectives, and beats, highlighting the current stage."""
+        if self._data.narrative_structure is None:
+            raise ValueError("No narrative structure selected")
+
+        structure = self._data.narrative_structure
+        stages = structure.stages
+        current_index = self._data.current_stage_index or 0
+
+        lines = [
+            f"Narrative structure: {structure.structure_type.name}",
+            f"Current stage: {current_index + 1}. {stages[current_index].name}",
+            "Stages:",
+        ]
+
+        for i, stage in enumerate(stages, start=1):
+            marker = " (current)" if (i - 1) == current_index else ""
+            lines.append(
+                f"- Stage {i}: {stage.name} - {stage.narrative_objectives}{marker}"
             )
-        else:
-            beats_summary = "No beats yet"
-        return f"Current stage: {stage.name}. Beats: {beats_summary}"
+            if stage.stage_beats:
+                beats = ", ".join(
+                    f"{beat.id} [{beat.status}]" for beat in stage.stage_beats
+                )
+            else:
+                beats = "No beats"
+            lines.append(f"  Beats: {beats}")
+
+        return "\n".join(lines)

--- a/backend/core_game/narrative/schemas.py
+++ b/backend/core_game/narrative/schemas.py
@@ -1,8 +1,10 @@
 from typing import Dict, List, Optional, Literal
 from pydantic import BaseModel, Field
 
-# Internal counter to generate sequential ids for narrative structures
+# Internal counters to generate sequential ids for narrative elements
 _structure_id_counter = 0
+_beat_id_counter = 0
+_failure_condition_id_counter = 0
 
 def _generate_structure_id() -> str:
     """Return a sequential id of the form 'structure_001'."""
@@ -10,13 +12,27 @@ def _generate_structure_id() -> str:
     _structure_id_counter += 1
     return f"structure_{_structure_id_counter:03d}"
 
+
+def generate_beat_id() -> str:
+    """Return a sequential id of the form 'beat_001'."""
+    global _beat_id_counter
+    _beat_id_counter += 1
+    return f"beat_{_beat_id_counter:03d}"
+
+
+def generate_failure_condition_id() -> str:
+    """Return a sequential id of the form 'failure_001'."""
+    global _failure_condition_id_counter
+    _failure_condition_id_counter += 1
+    return f"failure_{_failure_condition_id_counter:03d}"
+
 class GoalModel(BaseModel):
     """Defines a main goal for the player in the narrative. This will guide the narrative."""
     description: str = Field(..., description="Clear description of the goal to be achieved.")
 
 class NarrativeBeatModel(BaseModel):
     """Represents a unit of narrative progress."""
-    id: str = Field(..., description="Unique identifier of the narrative beat.")
+    id: str = Field(default_factory=generate_beat_id, description="Unique identifier of the narrative beat.")
     description: str = Field(..., description="Description of the goal/s or event/s represented by the beat.")
     status: Literal["PENDING", "ACTIVE", "COMPLETED", "FAILED", "DISCARDED"] = Field("PENDING", description="Current status of the beat.")
     origin: Optional[Literal["NARRATIVE_STAGE", "FAILURE_CONDITION"]] = Field(None, description="Where this beat originates from (narrative stage or failure condition).")
@@ -29,7 +45,7 @@ class RiskTriggeredBeats(BaseModel):
 
 class FailureConditionModel(BaseModel):
     """Defines a condition that can lead to an undesired narrative ending."""
-    id: str = Field(...,description="Failure condition id")
+    id: str = Field(default_factory=generate_failure_condition_id, description="Failure condition id")
     description: str = Field(..., description="Description of the failure condition.")
     risk_level: int = Field(0, ge=0, le=100, description="Current risk level (0-100).")
     is_active: bool = Field(False, description="Indicates whether this failure condition has been fully triggered (risk level reached 100) and the narrative has failed as a result.")

--- a/backend/simulated/game_state.py
+++ b/backend/simulated/game_state.py
@@ -218,6 +218,18 @@ class SimulatedGameState:
     def set_narrative_structure(self, structure_type: NarrativeStructureTypeModel) -> None:
         self._write_narrative.set_narrative_structure(structure_type)
 
+    def get_narrative_structure_details(self) -> str:
+        """Return overview of all stages with beats and highlight the current stage."""
+        return self._read_narrative.get_structure_details()
+
+    def get_current_stage_index(self) -> int:
+        """Return the index of the currently active narrative stage."""
+        return self._read_narrative.get_current_stage_index()
+
+    def get_next_stage_index(self) -> int:
+        """Return the index of the next narrative stage if available."""
+        return self._read_narrative.get_next_stage_index()
+
     def add_narrative_beat(self, stage_index: int, beat: NarrativeBeatModel) -> None:
         self._write_narrative.add_narrative_beat(stage_index, beat)
 

--- a/backend/subsystems/agents/narrative_handler/prompts/reasoning.py
+++ b/backend/subsystems/agents/narrative_handler/prompts/reasoning.py
@@ -12,6 +12,9 @@ You are 'NarrativeEngineAI', a specialized AI integrated into a **video game's d
 * The final narrative data you create and modify will drive the unfolding story for players.
 * You work alongside other AI agents that may be managing maps, characters, relationships, etc. **Your actions must be coherent with the overall game state.**
 
+**Narrative Beats Overview:**
+Narrative beats are units of story progression. More than one beat can be active at the same time, though some may initially be incompatible and represent alternative branches. Depending on how the game unfolds, one branch may be activated while others are discarded, or beats may trigger as consequences of previous ones. Inactive beats are simply possibilities for how the narrative might proceed. Active beats should not exclude one another and must be guided by the current stage and the main goal. Failure conditions represent alternative branches that can coexist alongside the main narrative and which the player should strive to avoid.
+
 **Your Primary Objective:**
 Interpret the user's high-level objective and execute a logical sequence of **API calls (using your available tools)** to modify the narrative until the objective is fully met. Pay close attention to any numerical targets or structural constraints, as meeting these is a primary condition for completion.
 

--- a/backend/subsystems/agents/narrative_handler/tools/__init__.py
+++ b/backend/subsystems/agents/narrative_handler/tools/__init__.py
@@ -1,6 +1,7 @@
 from .narrative_tools import (
     EXECUTORTOOLS,
     VALIDATIONTOOLS,
+    QUERYTOOLS,
     finalize_simulation,
     validate_simulated_narrative,
 )
@@ -8,6 +9,7 @@ from .narrative_tools import (
 __all__ = [
     "EXECUTORTOOLS",
     "VALIDATIONTOOLS",
+    "QUERYTOOLS",
     "finalize_simulation",
     "validate_simulated_narrative",
 ]


### PR DESCRIPTION
## Summary
- display beats and their status for each stage in `get_structure_details`
- expose beat info through simulated state and narrative query tool
- show all stages with their beat status in the initial summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d7e6a464832ea6e1f3f3c4c635aa