### PR TITLE
Add name to narrative beats

### DIFF
--- a/backend/core_game/narrative/domain.py
+++ b/backend/core_game/narrative/domain.py
@@ -134,7 +134,7 @@ class NarrativeState:
             lines.append(f"- Stage {i}: {stage.name}{marker}")
             if stage.stage_beats:
                 beats = ", ".join(
-                    f"{beat.id} [{beat.status}]" for beat in stage.stage_beats
+                    f"{beat.id}: {beat.name} [{beat.status}]" for beat in stage.stage_beats
                 )
             else:
                 beats = "No beats"
@@ -164,7 +164,7 @@ class NarrativeState:
             )
             if stage.stage_beats:
                 beats = ", ".join(
-                    f"{beat.id} [{beat.status}]" for beat in stage.stage_beats
+                    f"{beat.id}: {beat.name} [{beat.status}]" for beat in stage.stage_beats
                 )
             else:
                 beats = "No beats"


### PR DESCRIPTION
## Summary
- give NarrativeBeatModel a new `name` field
- auto-generate the name from the description when missing
- include beat names in narrative summaries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686429219200832e8c1fc79ae852602c