### PR TITLE
Improve failure condition summary

### DIFF
--- a/backend/core_game/narrative/domain.py
+++ b/backend/core_game/narrative/domain.py
@@ -142,4 +142,20 @@ class NarrativeState:
                 beats = "No beats"
             lines.append(f"  Beats: {beats}")
 
+        if self._data.failure_conditions:
+            lines.append("Failure conditions:")
+            for fc in self._data.failure_conditions:
+                total_beats = sum(len(rtb.beats) for rtb in fc.risk_triggered_beats)
+                not_triggered = sum(
+                    1
+                    for rtb in fc.risk_triggered_beats
+                    for beat in rtb.beats
+                    if beat.status == "PENDING"
+                )
+                lines.append(
+                    f"- {fc.id} (risk {fc.risk_level}%): {total_beats} beats, {not_triggered} not triggered"
+                )
+        else:
+            lines.append("No failure conditions")
+
         return "\n".join(lines)


### PR DESCRIPTION
## Summary
- enhance initial narrative summary to include failure condition risk levels and beat counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686438ca8814832eae5e21577eb52750