### PR TITLE
Add narrative query tools

### DIFF
--- a/backend/simulated/game_state.py
+++ b/backend/simulated/game_state.py
@@ -238,14 +238,45 @@ class SimulatedGameState:
     def set_failure_risk_level(self, condition_id: str, risk_level: int) -> None:
         self._write_narrative.set_failure_risk_level(condition_id, risk_level)
 
-    def get_current_stage_beats(self, stage_index: int):
+    def get_stage_beats(self, stage_index: int):
+        """Return beats for a given stage index."""
+        return self._read_narrative.get_stage_beats(stage_index)
+
+    def get_current_stage_beats(self):
+        """Return beats of the current narrative stage."""
+        index = self.get_current_stage_index()
+        return self.get_stage_beats(index)
+
+    def get_next_stage_beats(self):
+        """Return beats of the next narrative stage if available."""
+        index = self.get_next_stage_index()
+        return self.get_stage_beats(index)
+
+    def narrative_beats_count(self) -> int:
+        """Return the total number of beats tracked in the narrative."""
+        count = 0
         structure = self._read_narrative.get_state().narrative_structure
-        if structure is None:
-            raise ValueError("No narrative structure selected")
-        stages = structure.stages
-        if stage_index < 0 or stage_index >= len(stages):
-            raise IndexError("Stage index out of range")
-        return stages[stage_index].stage_beats
+        if structure:
+            for stage in structure.stages:
+                count += len(stage.stage_beats)
+        for fc in self._read_narrative.get_state().failure_conditions:
+            for rtb in fc.risk_triggered_beats:
+                count += len(rtb.beats)
+        return count
+
+    def get_narrative_beat(self, beat_id: str) -> NarrativeBeatModel | None:
+        """Return a beat by its id from any source."""
+        return self._read_narrative.get_beat(beat_id)
+
+    def get_failure_condition(self, condition_id: str) -> FailureConditionModel | None:
+        """Return a failure condition by id if it exists."""
+        return self._read_narrative.get_failure_condition(condition_id)
+
+    def list_active_beats(self) -> List[NarrativeBeatModel]:
+        return self._read_narrative.list_active_beats()
+
+    def list_pending_beats_main(self) -> List[NarrativeBeatModel]:
+        return self._read_narrative.list_pending_beats_main()
 
     # ---- MAP AND CHARACTER METHODS ----
     

--- a/backend/subsystems/agents/narrative_handler/tools/helpers.py
+++ b/backend/subsystems/agents/narrative_handler/tools/helpers.py
@@ -1,0 +1,40 @@
+from typing import Dict, Any, List
+
+
+def get_observation(total_beats: int, tool_name: str, success: bool, message: str) -> str:
+    """Generate a standardized observation string for narrative tools."""
+    result = "" if success else "Error,"
+    observation = (
+        f"Result of '{tool_name}': {result} {message} \nTotal narrative beats tracked: {total_beats}."
+    )
+    print(observation)
+    return observation
+
+
+def _format_nested_dict(data: Dict[str, Any], indent: int = 0) -> List[str]:
+    """Pretty-print a nested dictionary with clean indentation."""
+    lines: List[str] = []
+    indent_str = "    " * indent
+
+    for key, value in data.items():
+        display_key = str(key).replace("_", " ").capitalize()
+        if isinstance(value, dict):
+            lines.append(f"{indent_str}{display_key}:")
+            lines.extend(_format_nested_dict(value, indent + 1))
+        elif isinstance(value, list):
+            lines.append(f"{indent_str}{display_key}:")
+            if not value:
+                lines.append(f"{indent_str}    (None)")
+            else:
+                for item in value:
+                    if isinstance(item, dict):
+                        lines.append(f"{indent_str}    -")
+                        lines.extend(_format_nested_dict(item, indent + 2))
+                    else:
+                        lines.append(f"{indent_str}    - {item}")
+        elif value is None or value == "":
+            lines.append(f"{indent_str}{display_key}: (None)")
+        else:
+            lines.append(f"{indent_str}{display_key}: {value}")
+
+    return lines


### PR DESCRIPTION
## Summary
- add helper utilities for narrative observation and formatting
- extend `SimulatedNarrative` with search and listing capabilities
- expose new query methods in `SimulatedGameState`
- implement query tools for beats and failure conditions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643cdc45b8832eb1a44686819b79ee