### PR TITLE
Add narrative agent to refinement pipeline

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,11 @@
 
 from subsystems.generation.orchestrator import get_generation_graph_app
 from subsystems.generation.schemas.graph_state import GenerationGraphState
-from subsystems.generation.refinement_loop.pipelines import alternating_expansion_pipeline, map_characters_relationships_pipeline
+from subsystems.generation.refinement_loop.pipelines import (
+    alternating_expansion_pipeline,
+    map_characters_relationships_pipeline,
+    map_characters_relationships_narrative_pipeline,
+)
 from utils.visualize_graph import visualize_map_graph
 from core_game.game_state.singleton import GameStateSingleton
 
@@ -11,7 +15,7 @@ Apocaliptic world, zombie epidemic
 """
 
 if __name__ == "__main__":
-    pipeline = map_characters_relationships_pipeline()
+    pipeline = map_characters_relationships_narrative_pipeline()
     state = GenerationGraphState(
         initial_prompt=USER_PROMPT,
         refined_prompt_desired_word_length=200,

--- a/backend/subsystems/generation/refinement_loop/nodes.py
+++ b/backend/subsystems/generation/refinement_loop/nodes.py
@@ -134,6 +134,35 @@ def relationship_step_finish(state: RefinementLoopGraphState):
         "last_step_succeeded": state.relationships_task_succeeded_final,
     }
 
+def narrative_step_start(state: RefinementLoopGraphState):
+    """Sets up the state for the pass to refine the narrative"""
+
+    applied_operations_log = "Old operations summary: " + state.changelog_old_operations_summary + "Most recent operations:" + format_window(6, state.refinement_pass_changelog)
+    relevant_entities_str = ""
+    additional_info_str = ""
+    current_step = state.refinement_pipeline_config.steps[state.refinement_current_pass]
+    return {
+        "narrative_foundational_lore_document": state.refinement_foundational_world_info,
+        "narrative_recent_operations_summary": applied_operations_log,
+        "narrative_relevant_entity_details": relevant_entities_str,
+        "narrative_additional_information": additional_info_str,
+        "narrative_rules_and_constraints": current_step.rules_and_constraints,
+        "narrative_other_guidelines": current_step.other_guidelines,
+        "narrative_current_objective": current_step.objective_prompt,
+        "narrative_max_executor_iterations": current_step.max_executor_iterations,
+        "narrative_max_validation_iterations": current_step.max_validation_iterations,
+        "narrative_max_retries": current_step.max_retries,
+        "narrative_executor_applied_operations_log": ClearLogs(),
+        "narrative_validator_applied_operations_log": ClearLogs(),
+    }
+
+def narrative_step_finish(state: RefinementLoopGraphState):
+    """Postprocesses the finished narrative step."""
+    return {
+        "operations_log_to_summarize": state.narrative_executor_applied_operations_log,
+        "last_step_succeeded": state.narrative_task_succeeded_final,
+    }
+
 
 def finalize_step(state: RefinementLoopGraphState):
     """

--- a/backend/subsystems/generation/refinement_loop/orchestrator.py
+++ b/backend/subsystems/generation/refinement_loop/orchestrator.py
@@ -8,6 +8,7 @@ from subsystems.generation.refinement_loop.constants import AgentName
 from subsystems.agents.map_handler.orchestrator import get_map_graph_app
 from subsystems.agents.character_handler.orchestrator import get_character_graph_app
 from subsystems.agents.relationship_handler.orchestrator import get_relationship_graph_app
+from subsystems.agents.narrative_handler.orchestrator import get_narrative_graph_app
 
 def go_to_next_agent_or_finish(state: RefinementLoopGraphState) -> Union[AgentName, Literal["finalize"]]:
     """
@@ -38,6 +39,7 @@ def get_refinement_loop_graph_app():
     map_agent_sub_graph = get_map_graph_app()
     characters_agent_sub_graph = get_character_graph_app()
     relationship_agent_sub_graph = get_relationship_graph_app()
+    narrative_agent_sub_graph = get_narrative_graph_app()
 
     workflow.add_node("start_refinement_loop", start_refinement_loop)
     workflow.add_node("map_agent", map_agent_sub_graph)
@@ -49,6 +51,9 @@ def get_refinement_loop_graph_app():
     workflow.add_node("relationship_agent", relationship_agent_sub_graph)
     workflow.add_node("relationship_step_start", relationship_step_start)
     workflow.add_node("relationship_step_finish", relationship_step_finish)
+    workflow.add_node("narrative_agent", narrative_agent_sub_graph)
+    workflow.add_node("narrative_step_start", narrative_step_start)
+    workflow.add_node("narrative_step_finish", narrative_step_finish)
     workflow.add_node("finalize_step", finalize_step)
     workflow.add_node("prepare_next_step", prepare_next_step)
     workflow.add_node("summarize_agent_logs", summarize_sub_graph)
@@ -64,6 +69,7 @@ def get_refinement_loop_graph_app():
             AgentName.MAP: "map_step_start",
             AgentName.CHARACTERS: "characters_step_start",
             AgentName.RELATIONSHIP: "relationship_step_start",
+            AgentName.NARRATIVE: "narrative_step_start",
             "finalize": END,
         }
     )
@@ -75,6 +81,7 @@ def get_refinement_loop_graph_app():
             AgentName.MAP: "map_step_start",
             AgentName.CHARACTERS: "characters_step_start",
             AgentName.RELATIONSHIP: "relationship_step_start",
+            AgentName.NARRATIVE: "narrative_step_start",
             "finalize": END,
         }
     )
@@ -91,6 +98,10 @@ def get_refinement_loop_graph_app():
     workflow.add_edge("relationship_step_start", "relationship_agent")
     workflow.add_edge("relationship_agent", "relationship_step_finish")
     workflow.add_edge("relationship_step_finish", "finalize_step")
+
+    workflow.add_edge("narrative_step_start", "narrative_agent")
+    workflow.add_edge("narrative_agent", "narrative_step_finish")
+    workflow.add_edge("narrative_step_finish", "finalize_step")
 
     workflow.add_conditional_edges(
         "finalize_step",

--- a/backend/subsystems/generation/refinement_loop/pipelines.py
+++ b/backend/subsystems/generation/refinement_loop/pipelines.py
@@ -115,6 +115,56 @@ def map_characters_relationships_pipeline() -> PipelineConfig:
         ],
     )
 
+
+def map_characters_relationships_narrative_pipeline() -> PipelineConfig:
+    """Pipeline that generates a map, characters, relationships and a basic narrative."""
+    return PipelineConfig(
+        name="map_characters_relationships_narrative",
+        description="Generates map, characters, relationships and then crafts an initial narrative structure.",
+        steps=[
+            PipelineStep(
+                step_name="Initial Map",
+                agent_name=AgentName.MAP,
+                objective_prompt="Create a concise map with three connected scenarios.",
+                rules_and_constraints=[],
+                other_guidelines="",
+                max_executor_iterations=4,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+            PipelineStep(
+                step_name="Add Characters",
+                agent_name=AgentName.CHARACTERS,
+                objective_prompt="Introduce two characters placed in the generated scenarios.",
+                rules_and_constraints=[],
+                other_guidelines="",
+                max_executor_iterations=3,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+            PipelineStep(
+                step_name="Create Relationships",
+                agent_name=AgentName.RELATIONSHIP,
+                objective_prompt="Create relationships between the characters.",
+                rules_and_constraints=[],
+                other_guidelines="Ensure the relationships make sense with the character backgrounds and map.",
+                max_executor_iterations=3,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+            PipelineStep(
+                step_name="Create Narrative",
+                agent_name=AgentName.NARRATIVE,
+                objective_prompt="Create a short introductory narrative beat structure for the generated world.",
+                rules_and_constraints=[],
+                other_guidelines="",
+                max_executor_iterations=3,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+        ],
+    )
+
 def alternating_expansion_pipeline() -> PipelineConfig:
     """Pipeline with six steps alternating between map and characters."""
 
@@ -146,8 +196,8 @@ def alternating_expansion_pipeline() -> PipelineConfig:
                 max_executor_iterations=7,
                 max_validation_iterations=1,
                 max_retries=1,
-            )
         )
+    )
 
     return PipelineConfig(
         name="alternating_expansion",
@@ -163,4 +213,5 @@ __all__ = [
     "map_then_characters_pipeline",
     "alternating_expansion_pipeline",
     "map_characters_relationships_pipeline",
+    "map_characters_relationships_narrative_pipeline",
 ]

--- a/backend/subsystems/generation/refinement_loop/schemas/graph_state.py
+++ b/backend/subsystems/generation/refinement_loop/schemas/graph_state.py
@@ -7,9 +7,10 @@ from subsystems.generation.refinement_loop.schemas.pipeline_config import Pipeli
 from subsystems.agents.character_handler.schemas.graph_state import CharacterGraphState
 from subsystems.agents.map_handler.schemas.graph_state import MapGraphState
 from subsystems.agents.relationship_handler.schemas.graph_state import RelationshipGraphState
+from subsystems.agents.narrative_handler.schemas.graph_state import NarrativeGraphState
 from subsystems.summarize_agent_logs.schemas.graph_state import SummarizeLogsGraphState
 from subsystems.agents.utils.schemas import AgentLog
-class RefinementLoopGraphState(CharacterGraphState, MapGraphState, RelationshipGraphState, SummarizeLogsGraphState):
+class RefinementLoopGraphState(CharacterGraphState, MapGraphState, RelationshipGraphState, NarrativeGraphState, SummarizeLogsGraphState):
     """
     Manages the state of the iterative N-pass enrichment loop.
     """


### PR DESCRIPTION
## Summary
- include NarrativeGraphState in refinement loop state
- create narrative step start/finish nodes
- insert narrative agent subgraph into refinement orchestrator
- add new pipeline with narrative step
- update main entrypoint to use new pipeline

## Testing
- `python -m py_compile backend/main.py backend/subsystems/generation/refinement_loop/nodes.py backend/subsystems/generation/refinement_loop/orchestrator.py backend/subsystems/generation/refinement_loop/schemas/graph_state.py backend/subsystems/generation/refinement_loop/pipelines.py`

------
https://chatgpt.com/codex/tasks/task_e_68645e40ab10832ea8691a1073337eda