### PR TITLE
Implement game_event_handler agent

### DIFF
--- a/backend/subsystems/agents/game_event_handler/__init__.py
+++ b/backend/subsystems/agents/game_event_handler/__init__.py
@@ -1,0 +1,5 @@
+"""Game event management agent."""
+
+from .orchestrator import get_game_event_graph_app
+
+__all__ = ["get_game_event_graph_app"]

--- a/backend/subsystems/agents/game_event_handler/nodes.py
+++ b/backend/subsystems/agents/game_event_handler/nodes.py
@@ -1,0 +1,138 @@
+from dotenv import load_dotenv
+load_dotenv()
+
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import ToolNode
+from typing import Sequence
+
+from .schemas.graph_state import GameEventGraphState
+from .prompts.reasoning import format_game_event_reason_prompt
+from .prompts.validating import format_game_event_validation_prompt
+from .tools.event_tools import EXECUTORTOOLS, VALIDATIONTOOLS, validate_simulated_game_events
+from utils.message_window import get_valid_messages_window
+from langchain_core.messages import BaseMessage, HumanMessage, RemoveMessage
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+from simulated.singleton import SimulatedGameStateSingleton
+from subsystems.agents.utils.logs import ToolLog
+
+
+def receive_objective_node(state: GameEventGraphState):
+    print("---ENTERING: RECEIVE OBJECTIVE NODE---")
+    SimulatedGameStateSingleton.begin_transaction()
+    return {
+        "events_current_try": 0,
+        "messages_field_to_update": "events_executor_messages",
+        "logs_field_to_update": "events_executor_applied_operations_log",
+        "events_current_executor_iteration": 0,
+        "events_initial_summary": "",
+        "events_executor_messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES)],
+        "events_task_finalized_by_agent": False,
+        "events_task_finalized_justification": None,
+        "events_current_validation_iteration": 0,
+        "events_task_succeeded_final": False,
+    }
+
+
+def game_event_executor_reason_node(state: GameEventGraphState):
+    print("---ENTERING: REASON EXECUTION NODE---")
+    llm = ChatOpenAI(model="gpt-4.1-mini").bind_tools(EXECUTORTOOLS, tool_choice="any")
+    full_prompt = format_game_event_reason_prompt(
+        foundational_lore_document=state.events_foundational_lore_document,
+        recent_operations_summary=state.events_recent_operations_summary,
+        relevant_entity_details=state.events_relevant_entity_details,
+        additional_information=state.events_additional_information,
+        rules_and_constraints=state.events_rules_and_constraints,
+        initial_summary=state.events_initial_summary,
+        objective=state.events_current_objective,
+        other_guidelines=state.events_other_guidelines,
+        messages=get_valid_messages_window(state.events_executor_messages, 30),
+    )
+    state.events_current_executor_iteration += 1
+    response = llm.invoke(full_prompt)
+    return {
+        "events_executor_messages": [response],
+        "events_current_executor_iteration": state.events_current_executor_iteration,
+    }
+
+
+game_event_executor_tool_node = ToolNode(EXECUTORTOOLS)
+game_event_executor_tool_node.messages_key = "events_executor_messages"
+
+
+def receive_result_for_validation_node(state: GameEventGraphState):
+    print("---ENTERING: RECEIVE RESULT FOR VALIDATION NODE---")
+
+    def format_relevant_logs(operation_logs: Sequence[ToolLog]) -> str:
+        final_str = ""
+        for operation in operation_logs:
+            if operation.success and not operation.is_query:
+                final_str += f"Result of '{operation.tool_called}': {operation.message}\n"
+        return final_str
+
+    return {
+        "events_validation_messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES)],
+        "messages_field_to_update": "events_validation_messages",
+        "events_executor_agent_relevant_logs": format_relevant_logs(state.events_executor_applied_operations_log),
+        "logs_field_to_update": "events_validator_applied_operations_log",
+        "events_agent_validated": False,
+        "events_agent_validation_conclusion_flag": False,
+        "events_agent_validation_assessment_reasoning": "",
+        "events_agent_validation_suggested_improvements": "",
+        "events_current_validation_iteration": 0,
+    }
+
+
+def game_event_validation_reason_node(state: GameEventGraphState):
+    print("---ENTERING: REASON VALIDATION NODE---")
+    state.events_current_validation_iteration += 1
+    if state.events_current_validation_iteration <= state.events_max_validation_iterations:
+        validation_llm = ChatOpenAI(model="gpt-4.1-mini").bind_tools(VALIDATIONTOOLS, tool_choice="any")
+    else:
+        validation_llm = ChatOpenAI(model="gpt-4.1-mini").bind_tools([validate_simulated_game_events], tool_choice="any")
+    full_prompt = format_game_event_validation_prompt(
+        state.events_current_objective,
+        state.events_executor_agent_relevant_logs,
+        state.events_validation_messages,
+    )
+    response = validation_llm.invoke(full_prompt)
+    return {
+        "events_validation_messages": [response],
+        "events_current_validation_iteration": state.events_current_validation_iteration,
+    }
+
+
+game_event_validation_tool_node = ToolNode(VALIDATIONTOOLS)
+game_event_validation_tool_node.messages_key = "events_validation_messages"
+
+
+def retry_executor_node(state: GameEventGraphState):
+    print("---ENTERING: RETRY NODE---")
+    feedback = (
+        "Here's some human feedback on how you have done so far on your task:\n"
+        "You have still not completed your task\n Reason: "
+        f"{state.events_agent_validation_assessment_reasoning}\n Suggestion/s:{state.events_agent_validation_suggested_improvements} "
+    )
+    feedback_message = HumanMessage(feedback)
+    return {
+        "events_executor_messages": [feedback_message],
+        "messages_field_to_update": "events_executor_messages",
+        "logs_field_to_update": "events_executor_applied_operations_log",
+        "events_current_executor_iteration": 0,
+        "events_current_try": state.events_current_try + 1,
+    }
+
+
+def final_node_success(state: GameEventGraphState):
+    print("---ENTERING: LAST NODE OBJECTIVE SUCCESS---")
+    SimulatedGameStateSingleton.commit()
+    return {
+        "events_task_succeeded_final": True,
+    }
+
+
+def final_node_failure(state: GameEventGraphState):
+    print("---ENTERING: LAST NODE OBJECTIVE FAILED---")
+    SimulatedGameStateSingleton.rollback()
+    return {
+        "events_task_succeeded_final": False,
+    }

--- a/backend/subsystems/agents/game_event_handler/orchestrator.py
+++ b/backend/subsystems/agents/game_event_handler/orchestrator.py
@@ -1,0 +1,88 @@
+from langgraph.graph import StateGraph, END, START
+from langchain_core.messages import ToolMessage
+
+from .schemas.graph_state import GameEventGraphState
+from .nodes import (
+    receive_objective_node,
+    game_event_executor_reason_node,
+    game_event_executor_tool_node,
+    receive_result_for_validation_node,
+    game_event_validation_reason_node,
+    game_event_validation_tool_node,
+    retry_executor_node,
+    final_node_success,
+    final_node_failure,
+)
+
+
+def iteration_limit_exceeded_or_agent_finalized(state: GameEventGraphState) -> str:
+    current_iteration = state.events_current_executor_iteration
+    max_iterations = state.events_max_executor_iterations
+    if state.events_task_finalized_by_agent or current_iteration >= max_iterations:
+        if state.events_max_validation_iterations > 0:
+            return "finalize_executor_and_validate"
+        else:
+            return "finalize_executor_and_succeed"
+    else:
+        return "continue_executor"
+
+
+def iteration_limit_exceeded_or_agent_validated(state: GameEventGraphState) -> str:
+    current_iteration = state.events_current_validation_iteration
+    tries_to_evaluate_after_max_iterations = 3
+    max_iterations = state.events_max_validation_iterations + tries_to_evaluate_after_max_iterations
+    if state.events_agent_validated or current_iteration >= max_iterations:
+        if state.events_agent_validation_conclusion_flag:
+            return "finalize_success"
+        else:
+            if state.events_current_try <= state.events_max_retries:
+                return "retry_executor"
+            else:
+                return "finalize_failure"
+    else:
+        return "continue_validation"
+
+
+def get_game_event_graph_app():
+    workflow = StateGraph(GameEventGraphState)
+
+    workflow.add_node("executor_receive_objective", receive_objective_node)
+    workflow.add_node("executor_reason", game_event_executor_reason_node)
+    workflow.add_node("executor_tool", game_event_executor_tool_node)
+    workflow.add_node("validation_receive_result", receive_result_for_validation_node)
+    workflow.add_node("validation_reason", game_event_validation_reason_node)
+    workflow.add_node("validation_tool", game_event_validation_tool_node)
+    workflow.add_node("retry_executor", retry_executor_node)
+    workflow.add_node("final_node_success", final_node_success)
+    workflow.add_node("final_node_failure", final_node_failure)
+
+    workflow.add_edge(START, "executor_receive_objective")
+    workflow.add_edge("executor_receive_objective", "executor_reason")
+    workflow.add_edge("executor_reason", "executor_tool")
+    workflow.add_conditional_edges(
+        "executor_tool",
+        iteration_limit_exceeded_or_agent_finalized,
+        {
+            "continue_executor": "executor_reason",
+            "finalize_executor_and_validate": "validation_receive_result",
+            "finalize_executor_and_succeed": "final_node_success",
+        },
+    )
+    workflow.add_edge("validation_receive_result", "validation_reason")
+    workflow.add_edge("validation_reason", "validation_tool")
+    workflow.add_conditional_edges(
+        "validation_tool",
+        iteration_limit_exceeded_or_agent_validated,
+        {
+            "continue_validation": "validation_reason",
+            "finalize_success": "final_node_success",
+            "finalize_failure": "final_node_failure",
+            "retry_executor": "retry_executor",
+        },
+    )
+    workflow.add_edge("retry_executor", "executor_reason")
+    workflow.add_edge("final_node_success", END)
+    workflow.add_edge("final_node_failure", END)
+
+    app = workflow.compile()
+    return app

--- a/backend/subsystems/agents/game_event_handler/prompts/__init__.py
+++ b/backend/subsystems/agents/game_event_handler/prompts/__init__.py
@@ -1,0 +1,7 @@
+from .reasoning import format_game_event_reason_prompt
+from .validating import format_game_event_validation_prompt
+
+__all__ = [
+    "format_game_event_reason_prompt",
+    "format_game_event_validation_prompt",
+]

--- a/backend/subsystems/agents/game_event_handler/prompts/reasoning.py
+++ b/backend/subsystems/agents/game_event_handler/prompts/reasoning.py
@@ -1,0 +1,117 @@
+from typing import List, Sequence
+from langchain_core.prompts import ChatPromptTemplate
+from langchain.prompts import SystemMessagePromptTemplate, HumanMessagePromptTemplate, MessagesPlaceholder
+from langchain_core.messages import BaseMessage
+
+SYSTEM_PROMPT = """
+You are 'EventEngineAI', a specialized AI integrated into a **video game's development and simulation pipeline**. Your purpose is to manage the game's in-game events step-by-step, by directly manipulating the **game's state** through a set of provided tools.
+
+**Your Role in the Game Ecosystem:**
+* You are not just a creative writer; you are a **system operator**.
+* Your tool calls are **API requests** that modify a live, persistent database (the `GameState`).
+* The final event data you create and modify will drive the gameplay for players.
+* You work alongside other AI agents that may be managing maps, characters, relationships, narrative beats, etc. **Your actions must be coherent with the overall game state.**
+
+**Your Primary Objective:**
+Interpret the user's high-level objective and execute a logical sequence of **API calls (using your available tools)** to create or modify game events until the objective is fully met. Pay close attention to any numerical targets or structural constraints, as meeting these is a primary condition for completion.
+
+**Available Tools:**
+You have access to a set of tools. Each comes with a detailed description and a schema for its expected arguments. Use these tools exactly as defined. **Do not invent new tools or use any that are not listed.**
+
+**Your Work Process (ReAct Loop):**
+1. **REASON:** Carefully analyze the objective, the provided game context, the current events data (based on previous tool observations), and any feedback. Decide on the *next most logical action/s*.
+2. **ACT:** Choose the appropriate tool or tools and call them using the correct arguments.
+   - If you need more information about the current state of the events, USE QUERY TOOLS.
+   - If you have sufficient information, select the appropriate MODIFICATION tool or tools and apply them.
+3. **OBSERVE:** You will receive a result from each tool call. Use this information in your next reasoning step.
+4. **REPEAT:** Continue this Reason-Act-Observe cycle until you are confident that the `objective` has been fully satisfied.
+
+**Task Completion:**
+Once you are convinced that the simulated events fulfill the `objective` and are coherent:
+- You must call the `finalize_simulation` tool.
+- This tool requires a `justification` explaining why the **final event state is correct and complete** according to the objective.
+- This **MUST BE YOUR FINAL ACTION**. Do not call any other tools afterward.
+
+**Error Handling:**
+If a tool returns an error, analyze the error message in your OBSERVE step. In your next REASONING step, decide how to fix the issue: you may retry the tool with different arguments, try an alternative tool, or reconsider part of your strategy.
+"""
+
+HUMAN_PROMPT = """
+Below is all the information you need to complete your objective. Act accordingly.
+
+## 1. The World Context
+This is your **single initial source of truth** for the world's lore, tone, and context. ALL your actions must be deeply rooted in and consistent with this text. You must treat it as the project's "creative bible."
+
+### Foundational World Lore
+**This is the core creative document describing the world.** It represents the foundational seed used to generate everything. Your work must always be consistent with this lore.
+
+{foundational_lore_document}
+
+### Recent Operations Summary
+**This is a log of the most recent actions taken by other agents in the world, just before your turn.** It tells you what has just changed in the world and how it has expanded, providing immediate, unfolding context. **It is critical that you use this summary as a direct reference for your task to ensure your actions are coherent with the most recent world evolutions.**
+
+{recent_operations_summary}
+
+### Relevant Entity Information
+**Below are details of specific entities (characters, locations, items, etc.) that may or may not be relevant to your current task.** You can use this information directly to make informed decisions and to avoid making unnecessary queries with your tools. This section may be empty if no specific entities are deemed relevant.
+
+{relevant_entity_details}
+
+### Additional Information (Optional)
+**This section contains any other specific context, or data for this particular task.** This section may be empty.
+
+{additional_information}
+
+## 2. Supporting Information & Constraints
+This is additional or technical information that you must respect.
+
+### Rules and Constraints (Mandatory):
+THIS IS YOUR MOST IMPORTANT GUIDING PRINCIPLE: The 'Zero Context' Principle: Write everything for a total stranger. All descriptions MUST be self-contained, assuming zero prior knowledge of lore or rules.
+{rules_and_constraints}
+
+### Other Guidelines (Softer rules):
+{other_guidelines}
+
+### Initial Events Summary (if applicable):
+{initial_summary}
+
+## 3. Your Primary Objective
+**{objective}**
+
+You must achieve this objective in a way that honors and/or expands upon the world detailed in the context above.
+
+Begin your reasoning process now.
+"""
+
+chat_prompt_template = ChatPromptTemplate([
+    SystemMessagePromptTemplate.from_template(SYSTEM_PROMPT),
+    HumanMessagePromptTemplate.from_template(HUMAN_PROMPT),
+    MessagesPlaceholder(variable_name="agent_scratchpad"),
+])
+
+
+def format_game_event_reason_prompt(
+    foundational_lore_document: str,
+    recent_operations_summary: str,
+    relevant_entity_details: str,
+    additional_information: str,
+    rules_and_constraints: List[str],
+    initial_summary: str,
+    objective: str,
+    other_guidelines: str,
+    messages: Sequence[BaseMessage],
+) -> List[BaseMessage]:
+    prompt_input_values = {
+        "foundational_lore_document": foundational_lore_document,
+        "recent_operations_summary": recent_operations_summary,
+        "relevant_entity_details": relevant_entity_details,
+        "additional_information": additional_information,
+        "rules_and_constraints": "; ".join(rules_and_constraints),
+        "initial_summary": initial_summary,
+        "objective": objective,
+        "other_guidelines": other_guidelines,
+        "agent_scratchpad": messages,
+    }
+
+    formatted_messages = chat_prompt_template.format_messages(**prompt_input_values)
+    return formatted_messages

--- a/backend/subsystems/agents/game_event_handler/prompts/validating.py
+++ b/backend/subsystems/agents/game_event_handler/prompts/validating.py
@@ -1,0 +1,70 @@
+from typing import List, Sequence
+from langchain_core.prompts import ChatPromptTemplate
+from langchain.prompts import SystemMessagePromptTemplate, HumanMessagePromptTemplate, MessagesPlaceholder
+from langchain_core.messages import BaseMessage
+
+REACT_VALIDATOR_SYSTEM_PROMPT_TEMPLATE_STRING = """
+## ROLE ##
+You are a Game Event Validation Agent. Your specialty is to meticulously analyze the conformity of simulated events against a set of design objectives. You are logical, detail-oriented, and your reasoning is strictly based on the evidence provided.
+
+## Your Primary Objective ##
+Your primary mission is to **determine if the simulated events MEET or DO NOT MEET the `event_objective`**.
+
+## INPUT (Inputs You Will Receive) ##
+For each validation task, you will receive the following information:
+
+1. **`event_objective`**: A description of the rules, constraints and requirements the events were supposed to fulfill.
+2. **`constructor_agent_logs`**: A sequential record of actions and observation results from the agent that created or modified the events. These logs will allow you to understand the constructor agent's decision-making process.
+
+## Available Tools ##
+You have access to a set of tools. Each comes with a detailed description and a schema for its expected arguments. Use these tools exactly as defined. **Do not invent new tools or use any that are not listed.**
+
+## Your Work Process (ReAct Loop): ##
+1. **REASON:** Carefully analyze the objective, all provided context, the current state of the final simulated events (based on previous tool observations). Decide on the *next most logical action/s* to move toward the objective.
+2. **ACT:** Choose the appropriate tool/tools and call them using the correct arguments as defined in its schema.
+   - If you need more information about the current state of the events to make an informed decision, USE QUERY TOOLS.
+   - If you have sufficient information, select the validate tool to give a final validation.
+3. **OBSERVE:** You will receive a result from the tool. Use this information in your next reasoning step.
+4. **REPEAT:** Continue this Reason-Act-Observe cycle until you are confident that you can give a validation.
+
+## Task Completion ##
+Once you are convinced and have enough information to know whether the events MEET or DO NOT MEET the `event_objective`:
+- You must call the `validate_simulated_game_events` tool.
+- This tool requires a flag indicating if the events meet the objective or not, the reasoning behind this evaluation, and an argument to provide suggested improvements if the events did not satisfy the objective.
+- This **MUST BE YOUR FINAL ACTION**. Do not call any other tools afterward.
+"""
+
+REACT_VALIDATOR_HUMAN_PROMPT_TEMPLATE_STRING = """
+**1. Event Objective (`event_objective`):**
+{event_objective}
+**2. Constructor Agent Logs (`constructor_agent_logs`):**
+{constructor_agent_logs}
+"""
+
+REACT_VALIDATOR_SYSTEM_PROMPT_TEMPLATE = SystemMessagePromptTemplate.from_template(
+    REACT_VALIDATOR_SYSTEM_PROMPT_TEMPLATE_STRING
+)
+REACT_VALIDATOR_HUMAN_PROMPT_TEMPLATE = HumanMessagePromptTemplate.from_template(
+    REACT_VALIDATOR_HUMAN_PROMPT_TEMPLATE_STRING
+)
+
+chat_prompt_template = ChatPromptTemplate([
+    REACT_VALIDATOR_SYSTEM_PROMPT_TEMPLATE,
+    REACT_VALIDATOR_HUMAN_PROMPT_TEMPLATE,
+    MessagesPlaceholder(variable_name="agent_scratchpad"),
+])
+
+
+def format_game_event_validation_prompt(
+    event_objective: str,
+    constructor_agent_logs: str,
+    validating_messages: Sequence[BaseMessage],
+) -> List[BaseMessage]:
+    prompt_input_values = {
+        "event_objective": event_objective,
+        "constructor_agent_logs": constructor_agent_logs,
+        "agent_scratchpad": validating_messages,
+    }
+
+    formatted_messages = chat_prompt_template.format_messages(**prompt_input_values)
+    return formatted_messages

--- a/backend/subsystems/agents/game_event_handler/schemas/graph_state.py
+++ b/backend/subsystems/agents/game_event_handler/schemas/graph_state.py
@@ -1,0 +1,55 @@
+from typing import List, Optional, Sequence, Annotated
+from pydantic import BaseModel, Field
+from langchain_core.messages import BaseMessage
+from langgraph.graph.message import add_messages
+
+from subsystems.agents.utils.schemas import ToolLog
+from subsystems.agents.utils.logs import log_reducer
+
+
+class GameEventGraphState(BaseModel):
+    """Holds context and working memory for the game event agent."""
+
+    # Context and objectives
+    events_foundational_lore_document: str = Field(
+        default="",
+        alias="events_global_narrative_context",
+    )
+    events_recent_operations_summary: str = Field(default="")
+    events_relevant_entity_details: str = Field(default="")
+    events_additional_information: str = Field(default="")
+
+    events_rules_and_constraints: List[str] = Field(default_factory=list)
+    events_current_objective: str = Field(default="")
+    events_other_guidelines: str = Field(default="")
+    events_initial_summary: str = Field(default="")
+
+    # Flow control
+    events_max_retries: int = Field(default=1)
+    events_current_try: int = Field(default=1)
+
+    # Executor agent
+    events_executor_messages: Annotated[Sequence[BaseMessage], add_messages] = Field(default_factory=list)
+    events_current_executor_iteration: int = Field(default=0)
+    events_max_executor_iterations: int = Field(default=6)
+    events_task_finalized_by_agent: bool = Field(default=False)
+    events_task_finalized_justification: Optional[str] = Field(default=None)
+    events_executor_applied_operations_log: Annotated[Sequence[ToolLog], log_reducer] = Field(default_factory=list)
+
+    # Validation agent
+    events_max_validation_iterations: int = Field(default=3)
+    events_current_validation_iteration: int = Field(default=0)
+    events_executor_agent_relevant_logs: str = Field(default="")
+    events_validation_messages: Annotated[Sequence[BaseMessage], add_messages] = Field(default_factory=list)
+    events_agent_validation_conclusion_flag: bool = Field(default=False)
+    events_agent_validation_assessment_reasoning: str = Field(default="")
+    events_agent_validation_suggested_improvements: str = Field(default="")
+    events_agent_validated: bool = Field(default=False)
+    events_validator_applied_operations_log: Annotated[Sequence[ToolLog], log_reducer] = Field(default_factory=list)
+
+    # Finalizing
+    events_task_succeeded_final: bool = Field(default=False)
+
+    # Shared fields
+    logs_field_to_update: str = Field(default="logs")
+    messages_field_to_update: str = Field(default="messages")


### PR DESCRIPTION
## Summary
- add game_event handler package
- implement GameEventGraphState
- create reasoning and validating prompts
- add nodes and orchestrator for the new agent
- refine prompts to match narrative style

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68653344fa00832eb1688ddf6c79a7b5