### PR TITLE
Integrate Game Event Agent

### DIFF
--- a/backend/subsystems/agents/__init__.py
+++ b/backend/subsystems/agents/__init__.py
@@ -2,10 +2,12 @@ from .narrative_handler import get_narrative_graph_app
 from .map_handler import get_map_graph_app
 from .character_handler import get_character_graph_app
 from .relationship_handler import get_relationship_graph_app
+from .game_event_handler import get_game_event_graph_app
 
 __all__ = [
     "get_narrative_graph_app",
     "get_map_graph_app",
     "get_character_graph_app",
     "get_relationship_graph_app",
+    "get_game_event_graph_app",
 ]

--- a/backend/subsystems/generation/refinement_loop/constants.py
+++ b/backend/subsystems/generation/refinement_loop/constants.py
@@ -7,5 +7,6 @@ class AgentName(str, Enum):
     """
     NARRATIVE = "NarrativeAgent"
     MAP = "MapAgent"
-    CHARACTERS = "CharactersAgent" 
+    CHARACTERS = "CharactersAgent"
     RELATIONSHIP = "RelationshipAgent"
+    EVENTS = "GameEventAgent"

--- a/backend/subsystems/generation/refinement_loop/nodes.py
+++ b/backend/subsystems/generation/refinement_loop/nodes.py
@@ -163,6 +163,35 @@ def narrative_step_finish(state: RefinementLoopGraphState):
         "last_step_succeeded": state.narrative_task_succeeded_final,
     }
 
+def events_step_start(state: RefinementLoopGraphState):
+    """Sets up the state for the pass to refine the game events"""
+
+    applied_operations_log = "Old operations summary: " + state.changelog_old_operations_summary + "Most recent operations:" + format_window(6, state.refinement_pass_changelog)
+    relevant_entities_str = ""
+    additional_info_str = ""
+    current_step = state.refinement_pipeline_config.steps[state.refinement_current_pass]
+    return {
+        "events_foundational_lore_document": state.refinement_foundational_world_info,
+        "events_recent_operations_summary": applied_operations_log,
+        "events_relevant_entity_details": relevant_entities_str,
+        "events_additional_information": additional_info_str,
+        "events_rules_and_constraints": current_step.rules_and_constraints,
+        "events_other_guidelines": current_step.other_guidelines,
+        "events_current_objective": current_step.objective_prompt,
+        "events_max_executor_iterations": current_step.max_executor_iterations,
+        "events_max_validation_iterations": current_step.max_validation_iterations,
+        "events_max_retries": current_step.max_retries,
+        "events_executor_applied_operations_log": ClearLogs(),
+        "events_validator_applied_operations_log": ClearLogs(),
+    }
+
+def events_step_finish(state: RefinementLoopGraphState):
+    """Postprocesses the finished events step."""
+    return {
+        "operations_log_to_summarize": state.events_executor_applied_operations_log,
+        "last_step_succeeded": state.events_task_succeeded_final,
+    }
+
 
 def finalize_step(state: RefinementLoopGraphState):
     """

--- a/backend/subsystems/generation/refinement_loop/orchestrator.py
+++ b/backend/subsystems/generation/refinement_loop/orchestrator.py
@@ -9,6 +9,7 @@ from subsystems.agents.map_handler.orchestrator import get_map_graph_app
 from subsystems.agents.character_handler.orchestrator import get_character_graph_app
 from subsystems.agents.relationship_handler.orchestrator import get_relationship_graph_app
 from subsystems.agents.narrative_handler.orchestrator import get_narrative_graph_app
+from subsystems.agents.game_event_handler.orchestrator import get_game_event_graph_app
 
 def go_to_next_agent_or_finish(state: RefinementLoopGraphState) -> Union[AgentName, Literal["finalize"]]:
     """
@@ -40,6 +41,7 @@ def get_refinement_loop_graph_app():
     characters_agent_sub_graph = get_character_graph_app()
     relationship_agent_sub_graph = get_relationship_graph_app()
     narrative_agent_sub_graph = get_narrative_graph_app()
+    events_agent_sub_graph = get_game_event_graph_app()
 
     workflow.add_node("start_refinement_loop", start_refinement_loop)
     workflow.add_node("map_agent", map_agent_sub_graph)
@@ -54,6 +56,9 @@ def get_refinement_loop_graph_app():
     workflow.add_node("narrative_agent", narrative_agent_sub_graph)
     workflow.add_node("narrative_step_start", narrative_step_start)
     workflow.add_node("narrative_step_finish", narrative_step_finish)
+    workflow.add_node("events_agent", events_agent_sub_graph)
+    workflow.add_node("events_step_start", events_step_start)
+    workflow.add_node("events_step_finish", events_step_finish)
     workflow.add_node("finalize_step", finalize_step)
     workflow.add_node("prepare_next_step", prepare_next_step)
     workflow.add_node("summarize_agent_logs", summarize_sub_graph)
@@ -70,6 +75,7 @@ def get_refinement_loop_graph_app():
             AgentName.CHARACTERS: "characters_step_start",
             AgentName.RELATIONSHIP: "relationship_step_start",
             AgentName.NARRATIVE: "narrative_step_start",
+            AgentName.EVENTS: "events_step_start",
             "finalize": END,
         }
     )
@@ -82,6 +88,7 @@ def get_refinement_loop_graph_app():
             AgentName.CHARACTERS: "characters_step_start",
             AgentName.RELATIONSHIP: "relationship_step_start",
             AgentName.NARRATIVE: "narrative_step_start",
+            AgentName.EVENTS: "events_step_start",
             "finalize": END,
         }
     )
@@ -102,6 +109,10 @@ def get_refinement_loop_graph_app():
     workflow.add_edge("narrative_step_start", "narrative_agent")
     workflow.add_edge("narrative_agent", "narrative_step_finish")
     workflow.add_edge("narrative_step_finish", "finalize_step")
+
+    workflow.add_edge("events_step_start", "events_agent")
+    workflow.add_edge("events_agent", "events_step_finish")
+    workflow.add_edge("events_step_finish", "finalize_step")
 
     workflow.add_conditional_edges(
         "finalize_step",

--- a/backend/subsystems/generation/refinement_loop/pipelines.py
+++ b/backend/subsystems/generation/refinement_loop/pipelines.py
@@ -165,6 +165,66 @@ def map_characters_relationships_narrative_pipeline() -> PipelineConfig:
         ],
     )
 
+
+def map_characters_relationships_narrative_events_pipeline() -> PipelineConfig:
+    """Pipeline that generates a map, characters, relationships, narrative and game events."""
+    return PipelineConfig(
+        name="map_characters_relationships_narrative_events",
+        description="Generates map, characters, relationships, a basic narrative and then game events.",
+        steps=[
+            PipelineStep(
+                step_name="Initial Map",
+                agent_name=AgentName.MAP,
+                objective_prompt="Create a concise map with three connected scenarios.",
+                rules_and_constraints=[],
+                other_guidelines="",
+                max_executor_iterations=4,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+            PipelineStep(
+                step_name="Add Characters",
+                agent_name=AgentName.CHARACTERS,
+                objective_prompt="Introduce two characters placed in the generated scenarios.",
+                rules_and_constraints=[],
+                other_guidelines="",
+                max_executor_iterations=3,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+            PipelineStep(
+                step_name="Create Relationships",
+                agent_name=AgentName.RELATIONSHIP,
+                objective_prompt="Create 2-4 relationships between characters.",
+                rules_and_constraints=[],
+                other_guidelines="Ensure the relationships make sense with the character backgrounds and map.",
+                max_executor_iterations=3,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+            PipelineStep(
+                step_name="Create Narrative",
+                agent_name=AgentName.NARRATIVE,
+                objective_prompt="Create 2-3 narrative beats for the current stage and 1 failure condition.",
+                rules_and_constraints=[],
+                other_guidelines="",
+                max_executor_iterations=5,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+            PipelineStep(
+                step_name="Create Game Events",
+                agent_name=AgentName.EVENTS,
+                objective_prompt="Generate 2-3 key game events based on the narrative and world so far.",
+                rules_and_constraints=[],
+                other_guidelines="",
+                max_executor_iterations=4,
+                max_validation_iterations=1,
+                max_retries=1,
+            ),
+        ],
+    )
+
 def alternating_expansion_pipeline() -> PipelineConfig:
     """Pipeline with six steps alternating between map and characters."""
 
@@ -214,4 +274,5 @@ __all__ = [
     "alternating_expansion_pipeline",
     "map_characters_relationships_pipeline",
     "map_characters_relationships_narrative_pipeline",
+    "map_characters_relationships_narrative_events_pipeline",
 ]

--- a/backend/subsystems/generation/refinement_loop/schemas/graph_state.py
+++ b/backend/subsystems/generation/refinement_loop/schemas/graph_state.py
@@ -8,9 +8,10 @@ from subsystems.agents.character_handler.schemas.graph_state import CharacterGra
 from subsystems.agents.map_handler.schemas.graph_state import MapGraphState
 from subsystems.agents.relationship_handler.schemas.graph_state import RelationshipGraphState
 from subsystems.agents.narrative_handler.schemas.graph_state import NarrativeGraphState
+from subsystems.agents.game_event_handler.schemas.graph_state import GameEventGraphState
 from subsystems.summarize_agent_logs.schemas.graph_state import SummarizeLogsGraphState
 from subsystems.agents.utils.schemas import AgentLog
-class RefinementLoopGraphState(CharacterGraphState, MapGraphState, RelationshipGraphState, NarrativeGraphState, SummarizeLogsGraphState):
+class RefinementLoopGraphState(CharacterGraphState, MapGraphState, RelationshipGraphState, NarrativeGraphState, GameEventGraphState, SummarizeLogsGraphState):
     """
     Manages the state of the iterative N-pass enrichment loop.
     """


### PR DESCRIPTION
## Summary
- expose Game Event graph app in agent package
- include GameEvent agent enum and state in refinement loop
- add start/finish nodes and graph edges for game events
- extend pipelines with a narrative-events example

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'RiskTriggeredBeats')*

------
https://chatgpt.com/codex/tasks/task_e_68656590688c832e862a48700b6c37cc