### PR TITLE
Add activation condition removal tool

### DIFF
--- a/backend/core_game/game_event/activation_conditions/domain.py
+++ b/backend/core_game/game_event/activation_conditions/domain.py
@@ -1,8 +1,10 @@
-from abc import ABC, abstractmethod
-from typing import Dict, Any
+from __future__ import annotations
 
-# Assuming this is the path to your Singleton. Adjust if necessary!
-from simulated.game_state import SimulatedGameState
+from abc import ABC, abstractmethod
+from typing import Dict, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from simulated.game_state import SimulatedGameState
 
 # Import all the data models (schemas) that the domain classes will need
 from .schemas import *

--- a/backend/core_game/game_event/activation_conditions/schemas.py
+++ b/backend/core_game/game_event/activation_conditions/schemas.py
@@ -1,9 +1,24 @@
 from pydantic import BaseModel, Field
 from typing import Literal, Union
 
+_condition_id_counter = 0
+
+
+def generate_condition_id() -> str:
+    """Return a sequential id of the form 'condition_001'."""
+    global _condition_id_counter
+    _condition_id_counter += 1
+    return f"condition_{_condition_id_counter:03d}"
+
+
+def rollback_condition_id() -> None:
+    global _condition_id_counter
+    _condition_id_counter -= 1
+
 class ActivationConditionModel(BaseModel):
     """Base class for all activation condition models."""
-    type: str 
+    id: str = Field(default_factory=generate_condition_id, description="Unique identifier for the activation condition.")
+    type: str
 
 class AreaEntryConditionModel(ActivationConditionModel):
     """Activates when the player enters a specific scenario."""

--- a/backend/simulated/components/game_events.py
+++ b/backend/simulated/components/game_events.py
@@ -56,6 +56,12 @@ class SimulatedGameEvents:
 
         self._working_state.link_conditions_to_event(event_id, conditions)
 
+    def unlink_condition_from_event(self, event_id: str, condition_id: str) -> ActivationConditionModel:
+        """Delegates removal of a specific activation condition from an event."""
+        if not self._working_state.find_event(event_id):
+            raise KeyError(f"Event with ID '{event_id}' not found.")
+        return self._working_state.unlink_condition_from_event(event_id, condition_id)
+
 
     def list_events(self, status: Optional[str] = None) -> List[BaseGameEvent]:
         """Delegates event listing to the manager."""
@@ -64,3 +70,19 @@ class SimulatedGameEvents:
     def get_all_events_grouped(self) -> Dict[str, Dict[str, List[BaseGameEvent]]]:
         """Delegates grouping logic to the manager."""
         return self._working_state.get_all_events_grouped()
+
+    def delete_event(self, event_id: str) -> BaseGameEvent:
+        event = self._working_state.find_event(event_id)
+        if not event:
+            raise KeyError(f"Event with ID '{event_id}' not found.")
+        return self._working_state.delete_event(event_id)
+
+    def update_event_description(self, event_id: str, new_description: str) -> BaseGameEvent:
+        if not self._working_state.find_event(event_id):
+            raise KeyError(f"Event with ID '{event_id}' not found.")
+        return self._working_state.update_event_description(event_id, new_description)
+
+    def update_event_title(self, event_id: str, new_title: str) -> BaseGameEvent:
+        if not self._working_state.find_event(event_id):
+            raise KeyError(f"Event with ID '{event_id}' not found.")
+        return self._working_state.update_event_title(event_id, new_title)

--- a/backend/simulated/game_state.py
+++ b/backend/simulated/game_state.py
@@ -400,6 +400,48 @@ class SimulatedGameState:
         self._validate_activation_conditions(conditions)
         
         self.events.link_conditions_to_event(event_id, conditions)
-        
+
         print(f"--- Conditions successfully linked to event '{event_id}' ---")
+
+    def unlink_condition_from_event(self, event_id: str, condition_id: str) -> ActivationConditionModel:
+        """Orchestrates removal of an activation condition from an event."""
+        print(f"--- Orchestrating unlink of condition '{condition_id}' from event '{event_id}' ---")
+
+        event = self.read_only_events.find_event(event_id)
+        if not event:
+            raise KeyError(f"Event with ID '{event_id}' not found.")
+
+        if event.status in ["RUNNING", "COMPLETED"]:
+            raise ValueError(
+                f"Cannot unlink conditions from event '{event_id}'. It is already in '{event.status}' status."
+            )
+
+        removed = self.events.unlink_condition_from_event(event_id, condition_id)
+
+        print(
+            f"--- Condition '{condition_id}' successfully unlinked from event '{event_id}' ---"
+        )
+
+        return removed
+
+    def delete_event(self, event_id: str) -> BaseGameEvent:
+        """Orchestrates deletion of an event from the game state."""
+        event = self.read_only_events.find_event(event_id)
+        if not event:
+            raise KeyError(f"Event with ID '{event_id}' not found.")
+        return self.events.delete_event(event_id)
+
+    def update_event_description(self, event_id: str, new_description: str) -> BaseGameEvent:
+        """Update the description of an existing event."""
+        event = self.read_only_events.find_event(event_id)
+        if not event:
+            raise KeyError(f"Event with ID '{event_id}' not found.")
+        return self.events.update_event_description(event_id, new_description)
+
+    def update_event_title(self, event_id: str, new_title: str) -> BaseGameEvent:
+        """Update the title of an existing event."""
+        event = self.read_only_events.find_event(event_id)
+        if not event:
+            raise KeyError(f"Event with ID '{event_id}' not found.")
+        return self.events.update_event_title(event_id, new_title)
         


### PR DESCRIPTION
## Summary
- assign unique IDs to activation conditions
- implement `unlink_condition_from_event` in events manager and orchestrators
- expose unlink operation through simulated layers
- add `unlink_activation_condition` tool for agents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686944542fd4832e84cec811f0c280e7