### PR TITLE
Add DISABLED status for game events

### DIFF
--- a/backend/core_game/game_event/constants.py
+++ b/backend/core_game/game_event/constants.py
@@ -1,11 +1,12 @@
 from typing import Tuple, Literal, Union
 
-EVENT_STATUSES: Tuple[str, ...] = (        
+EVENT_STATUSES: Tuple[str, ...] = (
     "AVAILABLE",   # Ready to be triggered in the active game world.
+    "DISABLED",   # Won't be triggered while in this state.
     "RUNNING",     # Currently being executed.
     "COMPLETED"    # Finished and part of the historical record.
 )
 
-EVENT_STATUS_LITERAL = Literal["AVAILABLE", "RUNNING", "COMPLETED"]
+EVENT_STATUS_LITERAL = Literal["AVAILABLE", "DISABLED", "RUNNING", "COMPLETED"]
 
 

--- a/backend/core_game/game_event/domain.py
+++ b/backend/core_game/game_event/domain.py
@@ -416,6 +416,32 @@ class GameEventsManager:
         event.get_model().title = new_title
         return event
 
+    def disable_event(self, event_id: str) -> BaseGameEvent:
+        """Set the event status to DISABLED if currently AVAILABLE."""
+        event = self._all_events.get(event_id)
+        if not event:
+            raise KeyError(f"Event with ID '{event_id}' not found.")
+        if event.status != "AVAILABLE":
+            raise ValueError(
+                f"Cannot disable event '{event_id}' because it is in '{event.status}' status."
+            )
+
+        self.set_event_status(event_id, "DISABLED")
+        return event
+
+    def enable_event(self, event_id: str) -> BaseGameEvent:
+        """Set the event status back to AVAILABLE if currently DISABLED."""
+        event = self._all_events.get(event_id)
+        if not event:
+            raise KeyError(f"Event with ID '{event_id}' not found.")
+        if event.status != "DISABLED":
+            raise ValueError(
+                f"Cannot enable event '{event_id}' because it is in '{event.status}' status."
+            )
+
+        self.set_event_status(event_id, "AVAILABLE")
+        return event
+
     def get_all_events_grouped(self) -> Dict[str, Dict[str, List[BaseGameEvent]]]:
         """
         Returns all full event domain objects, grouped by beat and then by status.

--- a/backend/core_game/game_event/schemas.py
+++ b/backend/core_game/game_event/schemas.py
@@ -34,7 +34,10 @@ class GameEventModel(BaseModel):
         "narrator_intervention",
         "cutscene",
     ]
-    status: EVENT_STATUS_LITERAL = Field("AVAILABLE", description="The current lifecycle state of the event.")
+    status: EVENT_STATUS_LITERAL = Field(
+        "AVAILABLE",
+        description="The current lifecycle state of the event. If 'DISABLED', activation conditions will not trigger it.",
+    )
 
     activation_conditions: List[ActivationConditionModel] = Field(
         default_factory=list,

--- a/backend/simulated/components/game_events.py
+++ b/backend/simulated/components/game_events.py
@@ -91,3 +91,23 @@ class SimulatedGameEvents:
         if not self._working_state.find_event(event_id):
             raise KeyError(f"Event with ID '{event_id}' not found.")
         return self._working_state.update_event_title(event_id, new_title)
+
+    def disable_event(self, event_id: str) -> BaseGameEvent:
+        event = self._working_state.find_event(event_id)
+        if not event:
+            raise KeyError(f"Event with ID '{event_id}' not found.")
+        if event.status != "AVAILABLE":
+            raise ValueError(
+                f"Event '{event_id}' must be AVAILABLE to be disabled."
+            )
+        return self._working_state.disable_event(event_id)
+
+    def enable_event(self, event_id: str) -> BaseGameEvent:
+        event = self._working_state.find_event(event_id)
+        if not event:
+            raise KeyError(f"Event with ID '{event_id}' not found.")
+        if event.status != "DISABLED":
+            raise ValueError(
+                f"Event '{event_id}' must be DISABLED to be enabled."
+            )
+        return self._working_state.enable_event(event_id)

--- a/backend/simulated/game_state.py
+++ b/backend/simulated/game_state.py
@@ -397,6 +397,14 @@ class SimulatedGameState:
         
 
         self._validate_activation_conditions(conditions)
-        
+
         self.events.link_conditions_to_event(event_id, conditions)
+
+    def disable_event(self, event_id: str) -> BaseGameEvent:
+        """Convenience wrapper to disable an event if possible."""
+        return self.events.disable_event(event_id)
+
+    def enable_event(self, event_id: str) -> BaseGameEvent:
+        """Convenience wrapper to re-enable a disabled event."""
+        return self.events.enable_event(event_id)
         


### PR DESCRIPTION
## Summary
- expand the game event status enum with a new value `DISABLED`
- document the new state in GameEvent model
- introduce manager methods to enable or disable events
- expose enable/disable operations through simulator and agent tools

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686989f1f6a4832eb2dfc36e481f6de9